### PR TITLE
(Feat/#59) 팝업 디테일 조회 API 구현 

### DIFF
--- a/backend/src/main/java/com/example/demo/application/dto/PopupDetailResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/PopupDetailResponse.java
@@ -1,0 +1,22 @@
+package com.example.demo.application.dto;
+
+import com.example.demo.application.dto.popup.BrandStoryDto;
+import com.example.demo.application.dto.popup.LocationDto;
+import com.example.demo.application.dto.popup.PeriodDto;
+import com.example.demo.application.dto.popup.PopupDetailDto;
+import com.example.demo.application.dto.popup.RatingDto;
+import com.example.demo.application.dto.popup.SearchTagsDto;
+import java.util.List;
+
+public record PopupDetailResponse(
+    Long id,
+    List<String> thumbnails,
+    int dDay,
+    RatingDto rating,
+    String title,
+    SearchTagsDto searchTags,
+    LocationDto location,
+    PeriodDto period,
+    BrandStoryDto brandStory,
+    PopupDetailDto popupDetail
+) {}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/BrandStoryDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/BrandStoryDto.java
@@ -1,0 +1,8 @@
+package com.example.demo.application.dto.popup;
+
+import java.util.List;
+
+public record BrandStoryDto(
+    List<String> imageUrls,
+    List<SnsDto> sns
+) {}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/DayOfWeekInfoDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/DayOfWeekInfoDto.java
@@ -1,0 +1,6 @@
+package com.example.demo.application.dto.popup;
+
+public record DayOfWeekInfoDto(
+    String dayOfWeek,
+    String value
+) {}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/LocationDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/LocationDto.java
@@ -1,0 +1,11 @@
+package com.example.demo.application.dto.popup;
+
+public record LocationDto(
+    String addressName,
+    String region1depthName,
+    String region2depthName,
+    String region3depthName,
+    double longitude,
+    double latitude
+) {
+}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/PeriodDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/PeriodDto.java
@@ -1,0 +1,6 @@
+package com.example.demo.application.dto.popup;
+
+public record PeriodDto(
+    String startDate,
+    String endDate
+) {}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/PopupDetailDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/PopupDetailDto.java
@@ -1,0 +1,9 @@
+package com.example.demo.application.dto.popup;
+
+import java.util.List;
+
+public record PopupDetailDto(
+    List<DayOfWeekInfoDto> dayOfWeeks,
+    List<String> descriptions
+) {
+}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/RatingDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/RatingDto.java
@@ -1,7 +1,5 @@
 package com.example.demo.application.dto.popup;
 
-import com.example.demo.domain.model.Rating;
-
 public record RatingDto(
     double averageStar,
     int reviewCount

--- a/backend/src/main/java/com/example/demo/application/dto/popup/RatingDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/RatingDto.java
@@ -1,0 +1,9 @@
+package com.example.demo.application.dto.popup;
+
+import com.example.demo.domain.model.Rating;
+
+public record RatingDto(
+    double averageStar,
+    int reviewCount
+) {
+}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/SearchTagsDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/SearchTagsDto.java
@@ -1,0 +1,9 @@
+package com.example.demo.application.dto.popup;
+
+import java.util.List;
+
+public record SearchTagsDto(
+    String type,
+    List<String> category
+) {
+}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/SnsDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/SnsDto.java
@@ -1,0 +1,9 @@
+package com.example.demo.application.dto.popup;
+
+import com.example.demo.domain.model.Sns;
+
+public record SnsDto(
+    String icon,
+    String url
+) {
+}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/SnsDto.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/SnsDto.java
@@ -1,6 +1,5 @@
 package com.example.demo.application.dto.popup;
 
-import com.example.demo.domain.model.Sns;
 
 public record SnsDto(
     String icon,

--- a/backend/src/main/java/com/example/demo/application/mapper/PopupDetailMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/PopupDetailMapper.java
@@ -1,0 +1,111 @@
+package com.example.demo.application.mapper;
+
+import com.example.demo.application.dto.PopupDetailResponse;
+import com.example.demo.application.dto.popup.BrandStoryDto;
+import com.example.demo.application.dto.popup.DayOfWeekInfoDto;
+import com.example.demo.application.dto.popup.LocationDto;
+import com.example.demo.application.dto.popup.PeriodDto;
+import com.example.demo.application.dto.popup.PopupDetailDto;
+import com.example.demo.application.dto.popup.RatingDto;
+import com.example.demo.application.dto.popup.SearchTagsDto;
+import com.example.demo.application.dto.popup.SnsDto;
+import com.example.demo.domain.model.BrandStory;
+import com.example.demo.domain.model.DayOfWeekInfo;
+import com.example.demo.domain.model.Location;
+import com.example.demo.domain.model.Period;
+import com.example.demo.domain.model.PopupDetail;
+import com.example.demo.domain.model.PopupDetailInfo;
+import com.example.demo.domain.model.Rating;
+import com.example.demo.domain.model.SearchTags;
+import com.example.demo.domain.model.Sns;
+import java.time.DayOfWeek;
+import java.time.format.TextStyle;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PopupDetailMapper {
+
+    public PopupDetailResponse toResponse(PopupDetail popup) {
+        return new PopupDetailResponse(
+            popup.id(),
+            popup.thumbnails(),
+            popup.dDay(),
+            toRatingDto(popup.rating()),
+            popup.title(),
+            toSearchTagsDto(popup.searchTags()),
+            toLocationDto(popup.location()),
+            toPeriodDto(popup.period()),
+            toBrandStoryDto(popup.brandStory()),
+            toPopupDetailDto(popup.popupDetail())
+        );
+    }
+
+    private RatingDto toRatingDto(Rating rating) {
+        if (rating == null) return null;
+        return new RatingDto(rating.averageStar(), rating.reviewCount());
+    }
+
+    private SearchTagsDto toSearchTagsDto(SearchTags tags) {
+        if (tags == null) return null;
+        return new SearchTagsDto(tags.type(), tags.categoryNames());
+    }
+
+    private LocationDto toLocationDto(Location loc) {
+        if (loc == null) return null;
+        return new LocationDto(
+            loc.addressName(),
+            loc.region1depthName(),
+            loc.region2depthName(),
+            loc.region3depthName(),
+            loc.longitude(),
+            loc.latitude()
+        );
+    }
+
+    private PeriodDto toPeriodDto(Period period) {
+        if (period == null) return null;
+        return new PeriodDto(
+            period.startDate().toString(),
+            period.endDate().toString()
+        );
+    }
+
+    private BrandStoryDto toBrandStoryDto(BrandStory brandStory) {
+        if (brandStory == null) return null;
+        return new BrandStoryDto(
+            brandStory.imageUrls(),
+            brandStory.sns().stream()
+                .map(this::toSnsDto)
+                .toList()
+        );
+    }
+    private SnsDto toSnsDto(Sns sns) {
+        return new SnsDto(sns.icon(), sns.url());
+    }
+
+    private PopupDetailDto toPopupDetailDto(PopupDetailInfo detail) {
+        if (detail == null) return null;
+        return new PopupDetailDto(
+            detail.dayOfWeeks().stream()
+                .map(this::toDayOfWeekInfoDto)
+                .toList(),
+            detail.descriptions()
+        );
+    }
+    private DayOfWeekInfoDto toDayOfWeekInfoDto(DayOfWeekInfo d) {
+        return new DayOfWeekInfoDto(
+            abbreviateDayOfWeek(d.dayOfWeek()),
+            d.value()
+        );
+    }
+
+    private String abbreviateDayOfWeek(String fullName) {
+        try {
+            DayOfWeek dow = DayOfWeek.valueOf(fullName.toUpperCase());
+            return dow.getDisplayName(TextStyle.SHORT, Locale.ENGLISH).toUpperCase();
+        } catch (IllegalArgumentException e) {
+            return fullName;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/demo/application/service/PopupDetailReadService.java
+++ b/backend/src/main/java/com/example/demo/application/service/PopupDetailReadService.java
@@ -1,0 +1,23 @@
+package com.example.demo.application.service;
+
+import com.example.demo.application.dto.PopupDetailResponse;
+import com.example.demo.application.mapper.PopupDetailMapper;
+import com.example.demo.domain.port.PopupLoadPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PopupDetailReadService {
+
+    private final PopupLoadPort popupLoadPort;
+    private final PopupDetailMapper popupDetailMapper;
+
+    @Transactional(readOnly = true)
+    public PopupDetailResponse getPopupDetail(Long popupId) {
+        return popupLoadPort.findDetailById(popupId)
+            .map(popupDetailMapper::toResponse)
+            .orElseThrow(() -> new IllegalArgumentException("해당 팝업이 존재하지 않습니다."));
+    }
+}

--- a/backend/src/main/java/com/example/demo/domain/model/Rating.java
+++ b/backend/src/main/java/com/example/demo/domain/model/Rating.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.model;
 
+import java.util.List;
+
 /**
  * 리뷰 평점 도메인 모델.
  * 평균 별점과 리뷰 수를 나타낸다.
@@ -8,4 +10,15 @@ public record Rating(
     double averageStar,
     int reviewCount
 ) {
+    public static Rating from(List<Integer> ratings) {
+        if (ratings == null || ratings.isEmpty()) {
+            return new Rating(0.0, 0);
+        }
+        double average = ratings.stream()
+            .mapToInt(Integer::intValue)
+            .average()
+            .orElse(0.0);
+        average = Math.round(average * 10.0) / 10.0;
+        return new Rating(average, ratings.size());
+    }
 }

--- a/backend/src/main/java/com/example/demo/domain/port/PopupLoadPort.java
+++ b/backend/src/main/java/com/example/demo/domain/port/PopupLoadPort.java
@@ -1,0 +1,16 @@
+package com.example.demo.domain.port;
+
+import com.example.demo.domain.model.PopupDetail;
+import java.util.Optional;
+
+public interface PopupLoadPort {
+    /**
+     * ID로 팝업 상세 정보를 조회한다.
+     * 존재하지 않을 경우 Optional.empty()를 반환한다.
+     *
+     * @param popupId 조회할 팝업의 고유 식별자
+     * @return 팝업 상세 도메인 모델 (없으면 Optional.empty())
+     */
+    Optional<PopupDetail> findDetailById(Long popupId);
+
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupLoadAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupLoadAdapter.java
@@ -1,0 +1,124 @@
+package com.example.demo.infrastructure.persistence.adapter;
+
+import com.example.demo.application.mapper.PopupDetailMapper;
+import com.example.demo.domain.model.BrandStory;
+import com.example.demo.domain.model.DayOfWeekInfo;
+import com.example.demo.domain.model.Location;
+import com.example.demo.domain.model.Period;
+import com.example.demo.domain.model.PopupDetail;
+import com.example.demo.domain.model.PopupDetailInfo;
+import com.example.demo.domain.model.Rating;
+import com.example.demo.domain.model.SearchTags;
+import com.example.demo.domain.model.Sns;
+import com.example.demo.domain.port.PopupLoadPort;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupCategoryEntity;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupContentEntity;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupImageEntity;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupImageType;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupLocationEntity;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupReviewEntity;
+import com.example.demo.infrastructure.persistence.repository.PopupCategoryRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupContentRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupImageRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupLocationRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupReviewRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupSocialRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupWeeklyScheduleRepository;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PopupLoadAdapter implements PopupLoadPort {
+    private final PopupImageRepository popupImageRepository;
+    private final PopupCategoryRepository popupCategoryRepository;
+    private final PopupContentRepository popupContentRepository;
+    private final PopupLocationRepository popupLocationRepository;
+    private final PopupReviewRepository popupReviewRepository;
+    private final PopupSocialRepository popupSocialRepository;
+    private final PopupWeeklyScheduleRepository popupWeeklyScheduleRepository;
+    private final PopupDetailMapper popupDetailMapper;
+    private final PopupRepository popupRepository;
+
+    @Override
+    public Optional<PopupDetail> findDetailById(Long popupId) {
+        return popupRepository.findById(popupId).map(popup -> {
+
+            List<String> thumbnails = popupImageRepository.findAllByPopupIdAndTypeOrderBySortOrderAsc(popupId, PopupImageType.MAIN)
+                .stream()
+                .map(PopupImageEntity::getUrl)
+                .toList();
+
+            List<Integer> ratingValues = popupReviewRepository.findAllByPopupId(popupId)
+                .stream()
+                .map(PopupReviewEntity::getRating)
+                .toList();
+            Rating rating = Rating.from(ratingValues);
+
+            List<String> categories = popupCategoryRepository.findAllByPopupId(popupId)
+                .stream()
+                .map(PopupCategoryEntity::getName)
+                .toList();
+            SearchTags searchTags = new SearchTags(popup.getType().name(), categories);
+
+            PopupLocationEntity loc = popupLocationRepository.findById(popup.getPopupLocationId())
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 팝업 위치입니다."));
+            Location location = new Location(
+                loc.getAddressName(),
+                loc.getRegion1DepthName(),
+                loc.getRegion2DepthName(),
+                loc.getRegion3DepthName() != null ? loc.getRegion3DepthName() : "",
+                loc.getLongitude(),
+                loc.getLatitude()
+            );
+
+            Period period = new Period(popup.getStartDate(), popup.getEndDate());
+            int dDay = (int) ChronoUnit.DAYS.between(LocalDate.now(), popup.getEndDate());
+
+            List<String> brandImages = popupImageRepository.findAllByPopupIdAndTypeOrderBySortOrderAsc(popupId, PopupImageType.DESCRIPTION)
+                .stream()
+                .map(PopupImageEntity::getUrl)
+                .toList();
+
+            List<Sns> snsList = popupSocialRepository.findAllByPopupIdOrderBySortOrderAsc(popupId)
+                .stream()
+                .map(s -> new Sns(s.getIconUrl(), s.getLinkUrl()))
+                .toList();
+            BrandStory brandStory = new BrandStory(brandImages, snsList);
+
+            List<DayOfWeekInfo> dayOfWeeks = popupWeeklyScheduleRepository.findAllByPopupId(popupId)
+                .stream()
+                .map(s -> new DayOfWeekInfo(
+                    s.getDayOfWeek().name(),
+                    s.getOpenTime() + " ~ " + s.getCloseTime()
+                ))
+                .toList();
+
+            List<String> descriptions = popupContentRepository.findAllByPopupIdOrderBySortOrderAsc(popupId)
+                .stream()
+                .map(PopupContentEntity::getContentText)
+                .toList();
+
+            PopupDetailInfo popupDetailInfo = new PopupDetailInfo(dayOfWeeks, descriptions);
+
+            return new PopupDetail(
+                popup.getId(),
+                popup.getTitle(),
+                thumbnails,
+                dDay,
+                rating,
+                searchTags,
+                location,
+                period,
+                brandStory,
+                popupDetailInfo
+            );
+        });
+    }
+
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupCategoryRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.infrastructure.persistence.entity.popup.PopupCategoryEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupCategoryRepository extends JpaRepository<PopupCategoryEntity, Long> {
+
+    List<PopupCategoryEntity> findAllByPopupId(Long popupId);
+
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupContentRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupContentRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.infrastructure.persistence.entity.popup.PopupContentEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupContentRepository extends JpaRepository<PopupContentEntity,Long> {
+
+    List<PopupContentEntity> findAllByPopupIdOrderBySortOrderAsc(Long popupId);
+
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupImageRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupImageRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.infrastructure.persistence.entity.popup.PopupImageEntity;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupImageType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupImageRepository extends JpaRepository<PopupImageEntity, Long> {
+
+    List<PopupImageEntity> findAllByPopupIdAndTypeOrderBySortOrderAsc(Long id, PopupImageType popupImageType);
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupLocationRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupLocationRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.infrastructure.persistence.entity.popup.PopupLocationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupLocationRepository extends JpaRepository<PopupLocationEntity, Long> {
+
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.infrastructure.persistence.entity.popup.PopupEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupRepository extends JpaRepository<PopupEntity, Long> {
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupReviewRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupReviewRepository.java
@@ -1,0 +1,10 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.infrastructure.persistence.entity.popup.PopupReviewEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupReviewRepository extends JpaRepository<PopupReviewEntity, Long> {
+
+    List<PopupReviewEntity> findAllByPopupId(Long popupId);
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupSocialRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupSocialRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.infrastructure.persistence.entity.popup.PopupSocialEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupSocialRepository extends JpaRepository<PopupSocialEntity,Long> {
+
+    List<PopupSocialEntity> findAllByPopupIdOrderBySortOrderAsc(Long popupId);
+
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupWeeklyScheduleRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupWeeklyScheduleRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.infrastructure.persistence.entity.popup.PopupWeeklyScheduleEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupWeeklyScheduleRepository extends
+    JpaRepository<PopupWeeklyScheduleEntity, Long> {
+
+    List<PopupWeeklyScheduleEntity> findAllByPopupId(Long popupId);
+
+}

--- a/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
@@ -1,0 +1,23 @@
+package com.example.demo.presentation.controller;
+
+import com.example.demo.application.dto.PopupDetailResponse;
+import com.example.demo.application.service.PopupDetailReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/popups")
+@RequiredArgsConstructor
+public class PopupController {
+
+    private final PopupDetailReadService popupDetailReadService;
+
+    @GetMapping("/{popupId}")
+    public ResponseEntity<PopupDetailResponse> getPopupDetail(@PathVariable Long popupId) {
+        return ResponseEntity.ok(popupDetailReadService.getPopupDetail(popupId));
+    }
+}

--- a/backend/src/main/resources/sql/PopupData.sql
+++ b/backend/src/main/resources/sql/PopupData.sql
@@ -1,0 +1,87 @@
+
+-- ===================================
+-- ✅ [DATA] categories
+-- ===================================
+
+INSERT INTO categories (id, name)
+VALUES (100, '패션'),
+       (101, '예술');
+
+-- ===================================
+-- ✅ [DATA] members
+-- ===================================
+
+INSERT INTO members (id)
+VALUES (1000),
+       (1001);
+
+-- ===================================
+-- ✅ [DATA] popup_locations
+-- ===================================
+
+INSERT INTO popup_locations (id, address_name, region_1depth_name, region_2depth_name, region_3depth_name, longitude, latitude)
+VALUES (10, '경기도 성남시 분당구', '경기도', '성남시 분당구', '', 127.423084873712, 37.0789561558879);
+
+-- ===================================
+-- ✅ [DATA] popups
+-- ===================================
+
+INSERT INTO popups (id, title, popup_location_id, type, start_date, end_date)
+VALUES (1, '무신사 X 나이키 팝업스토어', 10, 'EXPERIENTIAL', '2025-06-01', '2025-06-25');
+
+-- ===================================
+-- ✅ [DATA] popup_categories
+-- ===================================
+
+INSERT INTO popup_categories (id, popup_id, category_id, name)
+VALUES (1, 1, 100, '패션'),
+       (2, 1, 101, '예술');
+
+-- ===================================
+-- ✅ [DATA] popup_images (MAIN)
+-- ===================================
+
+INSERT INTO popup_images (id, popup_id, type, url, sort_order)
+VALUES (1, 1, 'MAIN', 'https://example.com/images/popup1.jpg', 1),
+       (2, 1, 'MAIN', 'https://example.com/images/popup2.jpg', 2),
+       (3, 1, 'MAIN', 'https://example.com/images/popup3.jpg', 3);
+
+-- ===================================
+-- ✅ [DATA] popup_images (DESCRIPTION)
+-- ===================================
+
+INSERT INTO popup_images (id, popup_id, type, url, sort_order)
+VALUES (4, 1, 'DESCRIPTION', 'http://brand-story-image.com/1.jpg', 1),
+       (5, 1, 'DESCRIPTION', 'http://brand-story-image.com/2.jpg', 2),
+       (6, 1, 'DESCRIPTION', 'http://brand-story-image.com/3.jpg', 3);
+
+-- ===================================
+-- ✅ [DATA] popup_weekly_schedules
+-- ===================================
+
+INSERT INTO popup_weekly_schedules (id, popup_id, day_of_week, open_time, close_time)
+VALUES (1, 1, 'MONDAY', '11:00:00', '23:00:00'),
+       (2, 1, 'TUESDAY', '11:00:00', '23:00:00');
+
+-- ===================================
+-- ✅ [DATA] popup_contents
+-- ===================================
+
+INSERT INTO popup_contents (id, popup_id, content_text, sort_order)
+VALUES (1, 1, '설명 1', 1),
+       (2, 1, '설명 2', 2);
+
+-- ===================================
+-- ✅ [DATA] popup_socials
+-- ===================================
+
+INSERT INTO popup_socials (id, popup_id, icon_url, link_url, sort_order)
+VALUES (1, 1, 'http://icon.com', 'http://url.com', 1);
+
+-- ===================================
+-- ✅ [DATA] popup_reviews
+-- ===================================
+
+INSERT INTO popup_reviews (id, popup_id, member_id, rating, content)
+VALUES (1, 1, 1000, 4, '좋아요'),
+       (2, 1, 1001, 5, '최고예요');


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #59 

## 변경사항 설명
이 PR에서 어떤 변경사항이 있었는지 설명해주세요.

* 팝업 상세 조회 API 기능을 구현했습니다.

  * `PopupController`에 GET /api/popups/{popupId} 엔드포인트 추가
  * `PopupDetailReadService`에서 usecase 처리
  * `PopupLoadAdapter`에서 repository 호출 후 domain model 변환
  * `PopupDetailMapper`에서 domain model → application dto 변환 로직 구현
* Clean Architecture 원칙에 맞게 layer 의존성을 분리하였습니다.

  * domain → application → presentation 방향만 의존
  * dto가 domain model을 참조하지 않도록 분리
* 요일 약어 변환 로직을 mapper에 추가 (ex. MONDAY → MON)

## 일정
- 리뷰 요청 기한: 2025-07-05
- 머지 예정일: 2025-07-05


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
* 아키텍처 관련: domain, application, infrastructure, presentation 계층 분리 및 의존성 방향이 적절한지
* 성능 관련: 성능 고려하지 않음. 추후 테스트코드 작성 시 성능 고려.
* 보안 관련: 
* 기타: 
   - mapper에서 요일 변환 로직의 위치가 적절한지 검토
   - dDay가 음수면 프론트에서 종료와 같은 표현을 하게끔 하려고 하는데 의견 있으시면 좋겠습니다.

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. PopupData.sql 파일을 h2에서 실행
2. Postman에서 GET /api/popups/{popupId} 호출

## 체크리스트
- [ ] 테스트 코드를 작성했나요? (추후 작성 예정)
- [x] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.
![image](https://github.com/user-attachments/assets/b5b017e4-5b92-4769-945e-624d7c9cefd7)
![image](https://github.com/user-attachments/assets/bceda08f-e525-4749-ba41-60018d11bd91)

## 추가 정보
추가적인 정보나 컨텍스트가 있다면 여기에 작성해주세요. 

* dto 패키지와 mapper 패키지 구조도 리뷰 후 의견 주시면 반영하겠습니다.
