### PR TITLE
Bug/#77 내 방문/예약 내역 조회 API 오류 수정

### DIFF
--- a/backend/src/main/java/com/example/demo/Demo2Application.java
+++ b/backend/src/main/java/com/example/demo/Demo2Application.java
@@ -2,12 +2,14 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class Demo2Application {
 
     public static void main(String[] args) {
         SpringApplication.run(Demo2Application.class, args);
-        
+
     }
 }

--- a/backend/src/main/java/com/example/demo/application/service/WaitingService.java
+++ b/backend/src/main/java/com/example/demo/application/service/WaitingService.java
@@ -56,7 +56,7 @@ public class WaitingService {
                 request.contactEmail(),
                 request.peopleCount(),
                 nextWaitingNumber,
-                WaitingStatus.RESERVED,
+                WaitingStatus.WAITING,
                 LocalDateTime.now()
         );
 

--- a/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingQuery.java
+++ b/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingQuery.java
@@ -22,11 +22,6 @@ public record WaitingQuery(
          * RESERVED 상태가 먼저, 그 다음 날짜 최신순
          */
         RESERVED_FIRST_THEN_DATE_DESC,
-
-        /**
-         * 날짜 최신순
-         */
-        DATE_DESC
     }
 
     /**

--- a/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingStatus.java
+++ b/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingStatus.java
@@ -5,9 +5,10 @@ package com.example.demo.domain.model.waiting;
  * 대기의 현재 상태를 나타낸다.
  */
 public enum WaitingStatus {
-    RESERVED,    // 예약/대기중
-    COMPLETED,   // 방문완료
-    CANCELED;    // 취소됨
+    WAITING,    // 예약/대기중
+    VISITED,   // 방문완료
+    CANCELED,  // 취소됨
+    NONE;
 
     /**
      * 문자열을 WaitingStatus로 파싱한다.

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupPortAdapter.java
@@ -3,7 +3,7 @@ package com.example.demo.infrastructure.persistence.adapter;
 import com.example.demo.domain.model.popup.Popup;
 import com.example.demo.domain.port.PopupPort;
 import com.example.demo.infrastructure.persistence.entity.popup.PopupImageType;
-import com.example.demo.infrastructure.persistence.mapper.PopupMapper;
+import com.example.demo.infrastructure.persistence.mapper.PopupEntityMapper;
 import com.example.demo.infrastructure.persistence.repository.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ public class PopupPortAdapter implements PopupPort {
     private final PopupContentRepository popupContentRepository;
     private final PopupSocialRepository popupSocialRepository;
     private final PopupCategoryRepository popupCategoryRepository;
-    private final PopupMapper popupMapper;
+    private final PopupEntityMapper popupEntityMapper;
 
     @Override
     @Transactional(readOnly = true)
@@ -43,7 +43,7 @@ public class PopupPortAdapter implements PopupPort {
         var socialEntities = popupSocialRepository.findAllByPopupIdOrderBySortOrderAsc(popupId);
         var categoryEntities = popupCategoryRepository.findAllByPopupId(popupId);
 
-        Popup domain = popupMapper.toDomain(popupEntity, locationEntity, scheduleEntities, imageEntities, contentEntities, socialEntities, categoryEntities);
+        Popup domain = popupEntityMapper.toDomain(popupEntity, locationEntity, scheduleEntities, imageEntities, contentEntities, socialEntities, categoryEntities);
         return Optional.of(domain);
     }
 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/PopupEntityMapper.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/PopupEntityMapper.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-public class PopupMapper {
+public class PopupEntityMapper {
 
     // Entity List -> Domain
     public Popup toDomain(
@@ -54,11 +54,11 @@ public class PopupMapper {
         List<Sns> sns = socialEntities.stream().map(e -> new Sns(e.getIconUrl(), e.getLinkUrl())).collect(Collectors.toList());
         return new PopupDisplay(imageUrls, content, sns);
     }
-    
+
     private List<PopupCategory> toCategoriesDomain(List<PopupCategoryEntity> categoryEntities) {
         return categoryEntities.stream()
-            .map(e -> new PopupCategory(e.getCategoryId(), e.getName()))
-            .collect(Collectors.toList());
+                .map(e -> new PopupCategory(e.getCategoryId(), e.getName()))
+                .collect(Collectors.toList());
     }
 
     // Domain -> Entity
@@ -72,7 +72,7 @@ public class PopupMapper {
                 .endDate(popup.getSchedule().dateRange().endDate())
                 .build();
     }
-    
+
     // Type conversion methods
     private com.example.demo.domain.model.popup.PopupType toDomain(com.example.demo.infrastructure.persistence.entity.popup.PopupType entityType) {
         if (entityType == null) return null;
@@ -83,6 +83,6 @@ public class PopupMapper {
         if (domainType == null) return null;
         return com.example.demo.infrastructure.persistence.entity.popup.PopupType.valueOf(domainType.name());
     }
-    
+
     // ... 다른 도메인 -> 엔티티 매핑 메서드들
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
@@ -1,19 +1,20 @@
 package com.example.demo.infrastructure.persistence.repository;
 
 import com.example.demo.infrastructure.persistence.entity.popup.PopupEntity;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 /**
  * PopupEntity를 위한 Spring Data JPA Repository.
  */
 @Repository
 public interface PopupJpaRepository extends JpaRepository<PopupEntity, Long> {
-    
+
     /**
      * ID로 팝업을 조회한다.
-     * 
+     *
      * @param id 팝업 ID
      * @return 팝업 엔티티
      */

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/WaitingJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/WaitingJpaRepository.java
@@ -19,16 +19,6 @@ public interface WaitingJpaRepository extends JpaRepository<WaitingEntity, Long>
 
     /**
      * 회원 ID로 대기 목록을 조회한다.
-     * 생성일 기준 내림차순으로 정렬한다.
-     *
-     * @param memberId 회원 ID
-     * @param pageable 페이징 정보
-     * @return 대기 엔티티 목록
-     */
-    List<WaitingEntity> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
-
-    /**
-     * 회원 ID로 대기 목록을 조회한다.
      * RESERVED 상태가 먼저, 그 다음 생성일 기준 내림차순으로 정렬한다.
      *
      * @param memberId 회원 ID

--- a/backend/src/test/java/com/example/demo/application/mapper/WaitingDtoMapperTest.java
+++ b/backend/src/test/java/com/example/demo/application/mapper/WaitingDtoMapperTest.java
@@ -80,7 +80,7 @@ class WaitingDtoMapperTest {
             LocalDateTime registeredAt = LocalDateTime.now();
             Waiting waiting = new Waiting(
                     1L, validPopup, "홍길동", validMember,
-                    "hong@example.com", 2, 1, WaitingStatus.RESERVED, registeredAt
+                    "hong@example.com", 2, 1, WaitingStatus.WAITING, registeredAt
             );
 
             // when
@@ -104,7 +104,7 @@ class WaitingDtoMapperTest {
             LocalDateTime registeredAt = LocalDateTime.now();
             Waiting waiting = new Waiting(
                     2L, validPopup, "김철수", validMember,
-                    "kim@example.com", 3, 2, WaitingStatus.COMPLETED, registeredAt
+                    "kim@example.com", 3, 2, WaitingStatus.VISITED, registeredAt
             );
 
             // when
@@ -142,8 +142,8 @@ class WaitingDtoMapperTest {
                 .schedule(
                         new PopupSchedule(
                                 new DateRange(
-                                        LocalDate.now(),
-                                        LocalDate.now().plusDays(30)
+                                        LocalDate.of(2025, 7, 12),
+                                        LocalDate.of(2025, 7, 12).plusDays(30)
                                 ),
                                 new WeeklyOpeningHours(
                                         List.of(
@@ -179,7 +179,7 @@ class WaitingDtoMapperTest {
             LocalDateTime registeredAt = LocalDateTime.now();
             Waiting waiting = new Waiting(
                     1L, validPopup, "홍길동", validMember,
-                    "hong@example.com", 2, 1, WaitingStatus.RESERVED, registeredAt
+                    "hong@example.com", 2, 1, WaitingStatus.WAITING, registeredAt
             );
 
             // when
@@ -194,7 +194,7 @@ class WaitingDtoMapperTest {
             assertEquals("서울시 강남구", result.popup().location().addressName());
             assertEquals("2025-07-12 ~ 2025-08-11", result.popup().period());
             assertEquals(1, result.waitingNumber());
-            assertEquals("RESERVED", result.status());
+            assertEquals("WAITING", result.status());
         }
 
         @Test
@@ -217,8 +217,8 @@ class WaitingDtoMapperTest {
                     .schedule(
                             new PopupSchedule(
                                     new DateRange(
-                                            LocalDate.now(),
-                                            LocalDate.now().plusDays(30)
+                                            LocalDate.of(2025, 7, 12),
+                                            LocalDate.of(2025, 7, 12).plusDays(30)
                                     ),
                                     new WeeklyOpeningHours(
                                             List.of(
@@ -248,7 +248,7 @@ class WaitingDtoMapperTest {
             LocalDateTime registeredAt = LocalDateTime.now();
             Waiting waiting = new Waiting(
                     2L, popupWithoutThumbnails, "김철수", validMember,
-                    "kim@example.com", 3, 2, WaitingStatus.COMPLETED, registeredAt
+                    "kim@example.com", 3, 2, WaitingStatus.VISITED, registeredAt
             );
 
             // when
@@ -263,7 +263,7 @@ class WaitingDtoMapperTest {
             assertEquals("서울시 강남구", result.popup().location().addressName());
             assertEquals("2025-07-12 ~ 2025-08-11", result.popup().period());
             assertEquals(2, result.waitingNumber());
-            assertEquals("COMPLETED", result.status());
+            assertEquals("VISITED", result.status());
         }
     }
 } 

--- a/backend/src/test/java/com/example/demo/application/service/WaitingServiceTest.java
+++ b/backend/src/test/java/com/example/demo/application/service/WaitingServiceTest.java
@@ -1,11 +1,7 @@
 package com.example.demo.application.service;
 
-import com.example.demo.application.dto.waiting.VisitHistoryCursorResponse;
-import com.example.demo.application.dto.waiting.WaitingCreateRequest;
-import com.example.demo.application.dto.waiting.WaitingCreateResponse;
-import com.example.demo.application.dto.waiting.WaitingResponse;
-import com.example.demo.application.dto.waiting.PopupDtoForWaitingResponse;
 import com.example.demo.application.dto.popup.LocationResponse;
+import com.example.demo.application.dto.waiting.*;
 import com.example.demo.application.mapper.WaitingDtoMapper;
 import com.example.demo.domain.model.DateRange;
 import com.example.demo.domain.model.Location;
@@ -118,7 +114,7 @@ class WaitingServiceTest {
             Waiting savedWaiting = new Waiting(
                     1L, validPopup, "홍길동", validMember,
                     "hong@example.com", 2, nextWaitingNumber,
-                    WaitingStatus.RESERVED, registeredAt
+                    WaitingStatus.WAITING, registeredAt
             );
             Location location = validPopup.getLocation();
             LocationResponse locationResponse = new LocationResponse(
@@ -310,13 +306,13 @@ class WaitingServiceTest {
             Waiting waiting1 = new Waiting(
                     1L, validPopup, "홍길동", validMember,
                     "hong@example.com", 2, 1,
-                    WaitingStatus.RESERVED, LocalDateTime.now()
+                    WaitingStatus.WAITING, LocalDateTime.now()
             );
 
             Waiting waiting2 = new Waiting(
                     2L, validPopup, "김철수", validMember,
                     "kim@example.com", 3, 2,
-                    WaitingStatus.COMPLETED, LocalDateTime.now().minusDays(1));
+                    WaitingStatus.VISITED, LocalDateTime.now().minusDays(1));
 
             List<Waiting> waitings = List.of(waiting1, waiting2);
 
@@ -367,8 +363,8 @@ class WaitingServiceTest {
             Long lastWaitingId = null;
             String status = null;
 
-            Waiting waiting1 = new Waiting(1L, validPopup, "홍길동", validMember, "hong@example.com", 2, 1, WaitingStatus.RESERVED, LocalDateTime.now());
-            Waiting waiting2 = new Waiting(2L, validPopup, "김철수", validMember, "kim@example.com", 3, 2, WaitingStatus.COMPLETED, LocalDateTime.now().minusDays(1));
+            Waiting waiting1 = new Waiting(1L, validPopup, "홍길동", validMember, "hong@example.com", 2, 1, WaitingStatus.WAITING, LocalDateTime.now());
+            Waiting waiting2 = new Waiting(2L, validPopup, "김철수", validMember, "kim@example.com", 3, 2, WaitingStatus.VISITED, LocalDateTime.now().minusDays(1));
 
             List<Waiting> waitings = List.of(waiting1, waiting2);
 
@@ -378,7 +374,7 @@ class WaitingServiceTest {
                     5L, "6월 10일 ~ 6월 20일"
             );
             WaitingResponse waitingResponse1 = new WaitingResponse(1L, 1, "RESERVED", "홍길동", 2, "hong@example.com", popupDto1);
-            
+
             PopupDtoForWaitingResponse popupDto2 = new PopupDtoForWaitingResponse(
                     1L, "테스트 팝업", "thumbnail1.jpg",
                     new LocationResponse("서울시 강남구", "서울특별시", "강남구", "역삼동", 127.0012, 37.5665),
@@ -437,12 +433,12 @@ class WaitingServiceTest {
             // given
             Integer size = 10;
             Long lastWaitingId = null;
-            String status = "RESERVED";
+            String status = "WAITING";
 
             Waiting waiting = new Waiting(
                     1L, validPopup, "홍길동", validMember,
                     "hong@example.com", 2, 1,
-                    WaitingStatus.RESERVED, LocalDateTime.now()
+                    WaitingStatus.WAITING, LocalDateTime.now()
             );
 
             List<Waiting> waitings = List.of(waiting);
@@ -454,7 +450,7 @@ class WaitingServiceTest {
             );
 
             WaitingResponse waitingResponse = new WaitingResponse(
-                    1L, 1, "RESERVED", "홍길동", 2, "hong@example.com", popupDto
+                    1L, 1, status, "홍길동", 2, "hong@example.com", popupDto
             );
 
             when(waitingPort.findByQuery(any(WaitingQuery.class))).thenReturn(waitings);
@@ -466,7 +462,7 @@ class WaitingServiceTest {
             // then
             assertNotNull(response);
             assertEquals(1, response.content().size());
-            assertEquals("RESERVED", response.content().getFirst().status());
+            assertEquals("WAITING", response.content().getFirst().status());
 
             // verify
             verify(waitingPort).findByQuery(any(WaitingQuery.class));
@@ -484,7 +480,7 @@ class WaitingServiceTest {
             Waiting waiting = new Waiting(
                     6L, validPopup, "홍길동", validMember,
                     "hong@example.com", 2, 6,
-                    WaitingStatus.RESERVED, LocalDateTime.now()
+                    WaitingStatus.WAITING, LocalDateTime.now()
             );
 
             List<Waiting> waitings = List.of(waiting);

--- a/backend/src/test/java/com/example/demo/domain/model/waiting/WaitingTest.java
+++ b/backend/src/test/java/com/example/demo/domain/model/waiting/WaitingTest.java
@@ -71,7 +71,7 @@ class WaitingTest {
         String contactEmail = "hong@example.com";
         Integer peopleCount = 2;
         Integer waitingNumber = 1;
-        WaitingStatus status = WaitingStatus.RESERVED;
+        WaitingStatus status = WaitingStatus.WAITING;
         LocalDateTime registeredAt = LocalDateTime.now();
         // when & then
         assertDoesNotThrow(() -> new Waiting(
@@ -97,7 +97,7 @@ class WaitingTest {
                 IllegalArgumentException.class,
                 () -> new Waiting(
                         1L, validPopup, nullName, validMember,
-                        "test@example.com", 2, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                        "test@example.com", 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
                 )
         );
         assertEquals("대기자 이름은 2글자 이상 20글자 이하여야 합니다. 현재: null", exception.getMessage());
@@ -113,7 +113,7 @@ class WaitingTest {
                 IllegalArgumentException.class,
                 () -> new Waiting(
                         1L, validPopup, emptyName, validMember,
-                        "test@example.com", 2, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                        "test@example.com", 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
                 )
         );
         assertEquals("대기자 이름은 2글자 이상 20글자 이하여야 합니다. 현재: ", exception.getMessage());
@@ -129,7 +129,7 @@ class WaitingTest {
                 IllegalArgumentException.class,
                 () -> new Waiting(
                         1L, validPopup, shortName, validMember,
-                        "test@example.com", 2, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                        "test@example.com", 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
                 )
         );
         assertEquals("대기자 이름은 2글자 이상 20글자 이하여야 합니다. 현재: 홍", exception.getMessage());
@@ -145,7 +145,7 @@ class WaitingTest {
                 IllegalArgumentException.class,
                 () -> new Waiting(
                         1L, validPopup, longName, validMember,
-                        "test@example.com", 2, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                        "test@example.com", 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
                 )
         );
         assertEquals("대기자 이름은 2글자 이상 20글자 이하여야 합니다. 현재: 가나다라마바사아자차카타파하가나다라마바사아자차카타파하", exception.getMessage());
@@ -161,7 +161,7 @@ class WaitingTest {
                 IllegalArgumentException.class,
                 () -> new Waiting(
                         1L, validPopup, specialCharName, validMember,
-                        "test@example.com", 2, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                        "test@example.com", 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
                 )
         );
         assertEquals("대기자 이름에 특수문자는 포함될 수 없습니다. 현재: 홍길동!", exception.getMessage());
@@ -177,7 +177,7 @@ class WaitingTest {
                 IllegalArgumentException.class,
                 () -> new Waiting(
                         1L, validPopup, "홍길동", validMember,
-                        "test@example.com", nullPeopleCount, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                        "test@example.com", nullPeopleCount, 1, WaitingStatus.WAITING, LocalDateTime.now()
                 )
         );
         assertEquals("대기 인원수는 1명 이상 6명 이하여야 합니다. 현재: null", exception.getMessage());
@@ -193,7 +193,7 @@ class WaitingTest {
                 IllegalArgumentException.class,
                 () -> new Waiting(
                         1L, validPopup, "홍길동", validMember,
-                        "test@example.com", zeroPeopleCount, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                        "test@example.com", zeroPeopleCount, 1, WaitingStatus.WAITING, LocalDateTime.now()
                 )
         );
         assertEquals("대기 인원수는 1명 이상 6명 이하여야 합니다. 현재: 0", exception.getMessage());
@@ -209,7 +209,7 @@ class WaitingTest {
                 IllegalArgumentException.class,
                 () -> new Waiting(
                         1L, validPopup, "홍길동", validMember,
-                        "test@example.com", sevenPeopleCount, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                        "test@example.com", sevenPeopleCount, 1, WaitingStatus.WAITING, LocalDateTime.now()
                 )
         );
         assertEquals("대기 인원수는 1명 이상 6명 이하여야 합니다. 현재: 7", exception.getMessage());
@@ -223,7 +223,7 @@ class WaitingTest {
         // when & then
         assertDoesNotThrow(() -> new Waiting(
                 1L, validPopup, "홍길동", validMember,
-                "test@example.com", onePeopleCount, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                "test@example.com", onePeopleCount, 1, WaitingStatus.WAITING, LocalDateTime.now()
         ));
     }
 
@@ -235,7 +235,7 @@ class WaitingTest {
         // when & then
         assertDoesNotThrow(() -> new Waiting(
                 1L, validPopup, "홍길동", validMember,
-                "test@example.com", sixPeopleCount, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                "test@example.com", sixPeopleCount, 1, WaitingStatus.WAITING, LocalDateTime.now()
         ));
     }
 
@@ -247,7 +247,7 @@ class WaitingTest {
         // when & then
         assertDoesNotThrow(() -> new Waiting(
                 1L, validPopup, "홍길동", validMember,
-                validEmail, 2, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                validEmail, 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
         ));
     }
 
@@ -259,7 +259,7 @@ class WaitingTest {
         // when & then
         assertDoesNotThrow(() -> new Waiting(
                 1L, validPopup, "홍길동", validMember,
-                validEmail, 2, 1, WaitingStatus.RESERVED, LocalDateTime.now()
+                validEmail, 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
         ));
     }
 }

--- a/backend/src/test/java/com/example/demo/infrastructure/persistence/adapter/WaitingPortAdapterTest.java
+++ b/backend/src/test/java/com/example/demo/infrastructure/persistence/adapter/WaitingPortAdapterTest.java
@@ -1,0 +1,159 @@
+package com.example.demo.infrastructure.persistence.adapter;
+
+import com.example.demo.domain.model.Member;
+import com.example.demo.domain.model.popup.Popup;
+import com.example.demo.domain.model.waiting.Waiting;
+import com.example.demo.domain.model.waiting.WaitingQuery;
+import com.example.demo.domain.model.waiting.WaitingStatus;
+import com.example.demo.infrastructure.persistence.entity.WaitingEntity;
+import com.example.demo.infrastructure.persistence.mapper.WaitingEntityMapper;
+import com.example.demo.infrastructure.persistence.repository.WaitingJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.demo.domain.model.waiting.WaitingStatus.CANCELED;
+import static com.example.demo.domain.model.waiting.WaitingStatus.WAITING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@DataJpaTest
+@Import({WaitingPortAdapter.class, WaitingEntityMapper.class})
+class WaitingPortAdapterTest {
+
+    @Autowired
+    private WaitingPortAdapter waitingPortAdapter;
+
+    @Autowired
+    private WaitingJpaRepository waitingJpaRepository;
+
+    @MockitoBean
+    private PopupPortAdapter popupPortAdapter;
+
+    private Member member;
+    private Popup popup;
+
+    @BeforeEach
+    void setUp() {
+        waitingJpaRepository.deleteAll();
+        member = new Member(1L, "testUser", "test@example.com");
+        popup = Popup.builder().id(1L).name("test popup").build();
+    }
+
+    @Nested
+    @DisplayName("save 메서드 테스트")
+    class SaveTest {
+        @Test
+        @DisplayName("Waiting 도메인 객체를 저장하고, 저장된 객체를 반환한다")
+        void shouldSaveAndReturnWaiting() {
+            // given
+            Waiting waiting = new Waiting(
+                    null,
+                    popup,
+                    "방문객",
+                    member,
+                    "visitor@email.com",
+                    2,
+                    1,
+                    WAITING,
+                    LocalDateTime.now()
+            );
+
+            // when
+            Waiting savedWaiting = waitingPortAdapter.save(waiting);
+
+            // then
+            assertThat(savedWaiting).isNotNull();
+            assertThat(savedWaiting.popup()).isEqualTo(popup);
+            assertThat(savedWaiting.member()).isEqualTo(member);
+
+            Optional<WaitingEntity> foundEntity = waitingJpaRepository.findById(savedWaiting.id());
+            assertThat(foundEntity).isPresent();
+            assertThat(foundEntity.get().getWaitingPersonName()).isEqualTo("방문객");
+        }
+    }
+
+    @Nested
+    @DisplayName("getNextWaitingNumber 메서드 테스트")
+    class GetNextWaitingNumberTest {
+
+        @Test
+        @DisplayName("해당 팝업에 대기가 없으면 1을 반환한다")
+        void shouldReturnOneWhenNoWaitings() {
+            // when
+            Integer nextNumber = waitingPortAdapter.getNextWaitingNumber(popup.getId());
+
+            // then
+            assertThat(nextNumber).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("해당 팝업에 대기가 있으면 가장 큰 번호 + 1을 반환한다")
+        void shouldReturnMaxNumberPlusOne() {
+            // given
+            createAndSaveWaitingEntity(WAITING, 1);
+            createAndSaveWaitingEntity(WAITING, 2);
+
+            // when
+            Integer nextNumber = waitingPortAdapter.getNextWaitingNumber(popup.getId());
+
+            // then
+            assertThat(nextNumber).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByQuery 메서드 테스트")
+    class FindByQueryTest {
+
+        @BeforeEach
+        void setup() {
+            // given
+            // createdAt을 직접 설정하지 않고, 영속화 순서에 따라 DB에서 자동 생성되도록 함
+            createAndSaveWaitingEntity(WAITING, 1);
+            // CANCELED 상태의 데이터
+            createAndSaveWaitingEntity(CANCELED, 2);
+            // waiting1 보다 나중에 생성된 WAITING 상태의 데이터
+            createAndSaveWaitingEntity(WAITING, 3);
+
+
+            given(popupPortAdapter.findById(popup.getId())).willReturn(Optional.of(popup));
+        }
+
+        @Test
+        @DisplayName("정렬 조건이 RESERVED_FIRST_THEN_DATE_DESC 일때 WAITING, CANCELED 순으로 정렬되고 날짜 내림차순으로 정렬된다")
+        void shouldSortByStatusAndWaitThenDateDesc() {
+            // given
+            WaitingQuery query = new WaitingQuery(member.id(), 10, null, null, WaitingQuery.SortOrder.RESERVED_FIRST_THEN_DATE_DESC);
+
+            // when
+            List<Waiting> result = waitingPortAdapter.findByQuery(query);
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result).map(Waiting::status).containsExactly(WAITING, WAITING, CANCELED);
+        }
+    }
+
+    private void createAndSaveWaitingEntity(WaitingStatus status, int waitingNumber) {
+        WaitingEntity entity = WaitingEntity.builder()
+                .memberId(member.id())
+                .popupId(popup.getId())
+                .status(status)
+                .waitingNumber(waitingNumber)
+                .peopleCount(1)
+                .contactEmail("test@test.com")
+                .waitingPersonName("임수빈")
+                .build();
+        waitingJpaRepository.save(entity);
+    }
+} 


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #77 

## 변경사항 설명

- `WaitingPortAdpater.findByQuery()` 가 Popup 을 조회하지 않는 오류 수정
- WaitingPortAdpater 테스트 추가

## 일정
- 리뷰 요청 기한: 2025-07-13
- 머지 예정일: 2025-07-14

## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
  - `infrastructure.persistence.adapter` 가 다른 `adapter` 를 의존하도록 작성되어있습니다. 아키텍처 원칙을 생각해보면, 독립된 포트이므로 서로 의존 관계가 없는 것이 좋습니다. 다만, 이 경우 매우 많은 중복 코드가 작성되기 때문에 의존하는 것으로 타협했습니다.
- 성능 관련: 단일 조회 쿼리가 다수 발생하는 부분 개선 필요합니다. 추후 비슷한 경우들을 함께 처리하는게 좋을 듯 합니다.
- 보안 관련: 
- 기타: 

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. 현장 대기 API호출
2. 내 방문/예약 내역 조회 API 호출

## 체크리스트
- [x] 테스트 코드를 작성했나요?
- [x] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.

## 추가 정보
- 차주 백엔드 배포 작업 진행 시 테스트 코드 자동 수행 기능도 추가해야 할 듯 합니다. 이미 테스트 코드가 깨져있는 상태였습니다. 😂