### PR TITLE
(Feat/#47) 팝업 리스트 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/application/dto/popup/PopupCursorResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/PopupCursorResponse.java
@@ -1,0 +1,9 @@
+package com.example.demo.application.dto.popup;
+
+import java.util.List;
+
+public record PopupCursorResponse(
+    List<PopupSummaryResponse> content,
+    Long lastPopupId,
+    Boolean hasNext
+) {} 

--- a/backend/src/main/java/com/example/demo/application/dto/popup/PopupFilterRequest.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/PopupFilterRequest.java
@@ -1,0 +1,25 @@
+package com.example.demo.application.dto.popup;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+
+
+public record PopupFilterRequest(
+    Long popupId,
+    @Min(1)
+    Integer page,
+    @Min(1)
+    Integer size,
+    @Size(max = 3)
+    List<String> type,
+    @Size(max = 3)
+    List<String> category,
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    LocalDate startDate,
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    LocalDate endDate,
+    String region1DepthName
+) {}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/PopupFilterRequest.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/PopupFilterRequest.java
@@ -8,6 +8,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 
 public record PopupFilterRequest(
+    // TODO: https://github.com/JECT-Study/JECT-3th-6team/pull/92#discussion_r2210604215
     Long popupId,
     @Min(1)
     Integer size,

--- a/backend/src/main/java/com/example/demo/application/dto/popup/PopupFilterRequest.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/PopupFilterRequest.java
@@ -10,8 +10,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 public record PopupFilterRequest(
     Long popupId,
     @Min(1)
-    Integer page,
-    @Min(1)
     Integer size,
     @Size(max = 3)
     List<String> type,
@@ -21,5 +19,6 @@ public record PopupFilterRequest(
     LocalDate startDate,
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     LocalDate endDate,
-    String region1DepthName
+    String region1DepthName,
+    Long lastPopupId
 ) {}

--- a/backend/src/main/java/com/example/demo/application/dto/popup/PopupSummaryResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/PopupSummaryResponse.java
@@ -1,9 +1,7 @@
-package com.example.demo.application.dto.waiting;
-
-import com.example.demo.application.dto.popup.LocationResponse;
+package com.example.demo.application.dto.popup;
 
 // 다른 클래스에서 활용시 합의 필요
-public record PopupDtoForWaitingResponse(
+public record PopupSummaryResponse(
         Long popupId,
         String popupName,
         String popupImageUrl,

--- a/backend/src/main/java/com/example/demo/application/dto/waiting/WaitingResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/waiting/WaitingResponse.java
@@ -1,5 +1,7 @@
 package com.example.demo.application.dto.waiting;
 
+import com.example.demo.application.dto.popup.PopupSummaryResponse;
+
 /**
  * 방문 내역 조회에서 사용할 Waiting 객체 응답 DTO
  */
@@ -10,5 +12,5 @@ public record WaitingResponse(
     String name, // 예약자 이름
     int peopleCount, // 예약 인원
     String contactEmail, // 예약 이메일
-    PopupDtoForWaitingResponse popup
+    PopupSummaryResponse popup
 ) {} 

--- a/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
@@ -104,10 +104,23 @@ public class PopupDtoMapper {
             return PopupQuery.directPopupId(request.popupId());
         }
 
+        // 한글 타입명을 영어 Enum 값으로 매핑
+        List<String> mappedTypes = null;
+        if (request.type() != null) {
+            mappedTypes = request.type().stream()
+                .map(type -> switch (type) {
+                    case "체험형" -> "EXPERIENTIAL";
+                    case "전시형" -> "EXHIBITION";
+                    case "판매형" -> "SALES";
+                    default -> type; // 이미 영어면 그대로
+                })
+                .toList();
+        }
+
         return PopupQuery.withFilters(
             Optional.ofNullable(request.page()).orElse(1),
             Optional.ofNullable(request.size()).orElse(10),
-            request.type(),
+            mappedTypes,
             request.category(),
             request.startDate(),
             request.endDate(),

--- a/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
@@ -17,6 +17,7 @@ import com.example.demo.domain.model.popup.Popup;
 import com.example.demo.domain.model.popup.PopupCategory;
 import com.example.demo.domain.model.popup.PopupQuery;
 import com.example.demo.domain.model.popup.Sns;
+import com.example.demo.domain.model.popup.PopupType;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -108,11 +109,12 @@ public class PopupDtoMapper {
         List<String> mappedTypes = null;
         if (request.type() != null) {
             mappedTypes = request.type().stream()
-                .map(type -> switch (type) {
-                    case "체험형" -> "EXPERIENTIAL";
-                    case "전시형" -> "EXHIBITION";
-                    case "판매형" -> "SALES";
-                    default -> type; // 이미 영어면 그대로
+                .map(type -> {
+                    try {
+                        return PopupType.fromKorean(type).name();
+                    } catch (Exception e) {
+                        return type; // 예외 발생 시 원본 반환(혹시 모를 확장성)
+                    }
                 })
                 .toList();
         }

--- a/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
@@ -109,13 +109,7 @@ public class PopupDtoMapper {
         List<String> mappedTypes = null;
         if (request.type() != null) {
             mappedTypes = request.type().stream()
-                .map(type -> {
-                    try {
-                        return PopupType.fromKorean(type).name();
-                    } catch (Exception e) {
-                        return type; // 예외 발생 시 원본 반환(혹시 모를 확장성)
-                    }
-                })
+                .map(type -> PopupType.fromKorean(type).name())
                 .toList();
         }
 

--- a/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
@@ -111,7 +111,7 @@ public class PopupDtoMapper {
             request.category(),
             request.startDate(),
             request.endDate(),
-            request.region1DepthName()
+            (request.region1DepthName() == null || "전국".equals(request.region1DepthName())) ? null : request.region1DepthName()
         );
     }
     public PopupSummaryResponse toPopupSummaryResponse(Popup popup) {

--- a/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
@@ -118,13 +118,13 @@ public class PopupDtoMapper {
         }
 
         return PopupQuery.withFilters(
-            Optional.ofNullable(request.page()).orElse(1),
             Optional.ofNullable(request.size()).orElse(10),
             mappedTypes,
             request.category(),
             request.startDate(),
             request.endDate(),
-            (request.region1DepthName() == null || "전국".equals(request.region1DepthName())) ? null : request.region1DepthName()
+            (request.region1DepthName() == null || "전국".equals(request.region1DepthName())) ? null : request.region1DepthName(),
+            request.lastPopupId()
         );
     }
     public PopupSummaryResponse toPopupSummaryResponse(Popup popup) {

--- a/backend/src/main/java/com/example/demo/application/mapper/WaitingDtoMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/WaitingDtoMapper.java
@@ -1,6 +1,6 @@
 package com.example.demo.application.mapper;
 
-import com.example.demo.application.dto.waiting.PopupDtoForWaitingResponse;
+import com.example.demo.application.dto.popup.PopupSummaryResponse;
 import com.example.demo.application.dto.waiting.WaitingCreateResponse;
 import com.example.demo.application.dto.waiting.WaitingResponse;
 import com.example.demo.domain.model.DateRange;
@@ -56,7 +56,7 @@ public class WaitingDtoMapper {
                 waiting.waitingPersonName(),
                 waiting.peopleCount(),
                 waiting.contactEmail(),
-                new PopupDtoForWaitingResponse(
+                new PopupSummaryResponse(
                         popup.getId(),
                         popup.getName(),
                         popup.getDisplay().imageUrls().isEmpty() ? null : popup.getDisplay().imageUrls().getFirst(),

--- a/backend/src/main/java/com/example/demo/application/service/PopupService.java
+++ b/backend/src/main/java/com/example/demo/application/service/PopupService.java
@@ -1,8 +1,12 @@
 package com.example.demo.application.service;
 
 import com.example.demo.application.dto.PopupDetailResponse;
+import com.example.demo.application.dto.popup.PopupFilterRequest;
+import com.example.demo.application.dto.popup.PopupSummaryResponse;
 import com.example.demo.application.mapper.PopupDtoMapper;
 import com.example.demo.domain.model.BrandStory;
+import com.example.demo.domain.model.popup.Popup;
+import com.example.demo.domain.model.popup.PopupQuery;
 import com.example.demo.domain.model.waiting.Waiting;
 import com.example.demo.domain.model.waiting.WaitingStatus;
 import com.example.demo.domain.port.BrandStoryPort;
@@ -11,6 +15,7 @@ import com.example.demo.domain.port.WaitingPort;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +28,15 @@ public class PopupService {
     private final BrandStoryPort brandStoryPort;
     private final PopupDtoMapper popupDtoMapper;
     private final WaitingPort waitingPort;
+
+    @Transactional(readOnly = true)
+    public List<PopupSummaryResponse> getFilteredPopups(PopupFilterRequest request) {
+        PopupQuery query = popupDtoMapper.toQuery(request);
+        List<Popup> popups = popupPort.findByQuery(query);
+        return popups.stream()
+            .map(popupDtoMapper::toPopupSummaryResponse)
+            .toList();
+    }
 
     @Transactional(readOnly = true)
     public PopupDetailResponse getPopupDetail(Long popupId, Long memberId) {

--- a/backend/src/main/java/com/example/demo/application/service/PopupService.java
+++ b/backend/src/main/java/com/example/demo/application/service/PopupService.java
@@ -33,6 +33,7 @@ public class PopupService {
 
     @Transactional(readOnly = true)
     public PopupCursorResponse getFilteredPopups(PopupFilterRequest request) {
+        // TODO: https://github.com/JECT-Study/JECT-3th-6team/pull/92#discussion_r2210591165
         PopupQuery query = popupDtoMapper.toQuery(request);
         int size = Optional.ofNullable(request.size()).orElse(10);
         List<Popup> popups = popupPort.findByQuery(query);

--- a/backend/src/main/java/com/example/demo/application/service/PopupService.java
+++ b/backend/src/main/java/com/example/demo/application/service/PopupService.java
@@ -41,7 +41,7 @@ public class PopupService {
             .limit(size)
             .map(popupDtoMapper::toPopupSummaryResponse)
             .toList();
-        Long lastPopupId = content.isEmpty() ? null : content.get(content.size() - 1).popupId();
+        Long lastPopupId = content.isEmpty() ? null : content.getLast().popupId();
         return new PopupCursorResponse(content, lastPopupId, hasNext);
     }
 

--- a/backend/src/main/java/com/example/demo/domain/model/popup/PopupQuery.java
+++ b/backend/src/main/java/com/example/demo/domain/model/popup/PopupQuery.java
@@ -9,6 +9,7 @@ import java.util.Optional;
  * 페이징, 필터링, 정렬 조건 등을 포함할 수 있다.
  */
 public record PopupQuery(
+    // TODO: https://github.com/JECT-Study/JECT-3th-6team/pull/92#discussion_r2210630218
     Long popupId,
     int size,
     List<String> types,

--- a/backend/src/main/java/com/example/demo/domain/model/popup/PopupQuery.java
+++ b/backend/src/main/java/com/example/demo/domain/model/popup/PopupQuery.java
@@ -1,9 +1,46 @@
 package com.example.demo.domain.model.popup;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
 /**
  * 팝업 조회를 위한 조건들을 담는 객체.
  * 페이징, 필터링, 정렬 조건 등을 포함할 수 있다.
  */
-public class PopupQuery {
-    // TODO: 페이징 정보, 상태 필터 등 구체적인 조회 조건 구현 필요
-} 
+public record PopupQuery(
+    Long popupId,
+    int page,
+    int size,
+    List<String> types,
+    List<String> categories,
+    LocalDate startDate,
+    LocalDate endDate,
+    String region1DepthName
+) {
+
+    public static PopupQuery directPopupId(Long popupId) {
+        return new PopupQuery(popupId, 1, 1, List.of(), List.of(), null, null, null);
+    }
+
+    public static PopupQuery withFilters(
+        int page,
+        int size,
+        List<String> types,
+        List<String> categories,
+        LocalDate startDate,
+        LocalDate endDate,
+        String region1DepthName
+    ) {
+        return new PopupQuery(
+            null,
+            page,
+            size,
+            Optional.ofNullable(types).orElse(List.of()),
+            Optional.ofNullable(categories).orElse(List.of()),
+            startDate,
+            endDate,
+            region1DepthName
+        );
+    }
+}

--- a/backend/src/main/java/com/example/demo/domain/model/popup/PopupQuery.java
+++ b/backend/src/main/java/com/example/demo/domain/model/popup/PopupQuery.java
@@ -10,37 +10,37 @@ import java.util.Optional;
  */
 public record PopupQuery(
     Long popupId,
-    int page,
     int size,
     List<String> types,
     List<String> categories,
     LocalDate startDate,
     LocalDate endDate,
-    String region1DepthName
+    String region1DepthName,
+    Long lastPopupId
 ) {
 
     public static PopupQuery directPopupId(Long popupId) {
-        return new PopupQuery(popupId, 1, 1, List.of(), List.of(), null, null, null);
+        return new PopupQuery(popupId, 1, List.of(), List.of(), null, null, null, null);
     }
 
     public static PopupQuery withFilters(
-        int page,
         int size,
         List<String> types,
         List<String> categories,
         LocalDate startDate,
         LocalDate endDate,
-        String region1DepthName
+        String region1DepthName,
+        Long lastPopupId
     ) {
         return new PopupQuery(
             null,
-            page,
             size,
             Optional.ofNullable(types).orElse(List.of()),
             Optional.ofNullable(categories).orElse(List.of()),
             startDate,
             endDate,
-            region1DepthName
+            region1DepthName,
+            lastPopupId
         );
     }
 }

--- a/backend/src/main/java/com/example/demo/domain/model/popup/PopupType.java
+++ b/backend/src/main/java/com/example/demo/domain/model/popup/PopupType.java
@@ -8,13 +8,37 @@ public enum PopupType {
     /**
      * 체험형
      */
-    EXPERIENTIAL,
+    EXPERIENTIAL("체험형"),
     /**
      * 전시형
      */
-    EXHIBITION,
+    EXHIBITION("전시형"),
     /**
      * 판매형
      */
-    RETAIL
+    RETAIL("판매형");
+
+    private final String korean;
+
+    PopupType(String korean) {
+        this.korean = korean;
+    }
+
+    public String getKorean() {
+        return korean;
+    }
+
+    public static PopupType fromKorean(String value) {
+        for (PopupType type : values()) {
+            if (type.korean.equals(value)) {
+                return type;
+            }
+        }
+        // 이미 영어로 들어온 경우도 지원
+        try {
+            return PopupType.valueOf(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("지원하지 않는 팝업 타입: " + value);
+        }
+    }
 } 

--- a/backend/src/main/java/com/example/demo/domain/model/popup/PopupType.java
+++ b/backend/src/main/java/com/example/demo/domain/model/popup/PopupType.java
@@ -34,11 +34,6 @@ public enum PopupType {
                 return type;
             }
         }
-        // 이미 영어로 들어온 경우도 지원
-        try {
-            return PopupType.valueOf(value);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("지원하지 않는 팝업 타입: " + value);
-        }
+        throw new IllegalArgumentException("지원하지 않는 팝업 타입(한글): " + value);
     }
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupPortAdapter.java
@@ -1,17 +1,25 @@
 package com.example.demo.infrastructure.persistence.adapter;
 
 import com.example.demo.domain.model.popup.Popup;
+import com.example.demo.domain.model.popup.PopupQuery;
 import com.example.demo.domain.port.PopupPort;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupEntity;
 import com.example.demo.infrastructure.persistence.entity.popup.PopupImageType;
 import com.example.demo.infrastructure.persistence.mapper.PopupEntityMapper;
-import com.example.demo.infrastructure.persistence.repository.*;
+import com.example.demo.infrastructure.persistence.repository.PopupCategoryRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupContentRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupImageRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupJpaRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupLocationRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupSocialRepository;
+import com.example.demo.infrastructure.persistence.repository.PopupWeeklyScheduleRepository;
 import jakarta.persistence.EntityNotFoundException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -57,10 +65,30 @@ public class PopupPortAdapter implements PopupPort {
         throw new UnsupportedOperationException("Save operation is not yet implemented");
     }
 
-    @Override
-    public List<Popup> findByQuery(com.example.demo.domain.model.popup.PopupQuery query) {
-        // TODO: QueryDSL 등을 사용하여 동적 쿼리 구현 필요
-        return List.of();
+    public List<Popup> findByQuery(PopupQuery query) {
+        var pageable = PageRequest.of(query.page() - 1, query.size());
+
+        List<PopupEntity> popupEntities = popupJpaRepository.findFilteredPopups(
+            query.popupId(),
+            query.startDate(),
+            query.endDate(),
+            query.types().isEmpty() ? null : query.types(),
+            query.categories().isEmpty() ? null : query.categories(),
+            query.region1DepthName(),
+            pageable
+        );
+
+        return popupEntities.stream()
+            .map(entity -> {
+                var location = popupLocationRepository.findById(entity.getPopupLocationId()).orElse(null);
+                var schedules = popupWeeklyScheduleRepository.findAllByPopupId(entity.getId());
+                var images = popupImageRepository.findAllByPopupIdAndTypeOrderBySortOrderAsc(entity.getId(), PopupImageType.MAIN);
+                var contents = popupContentRepository.findAllByPopupIdOrderBySortOrderAsc(entity.getId());
+                var socials = popupSocialRepository.findAllByPopupIdOrderBySortOrderAsc(entity.getId());
+                var categories = popupCategoryRepository.findAllByPopupId(entity.getId());
+                return popupEntityMapper.toDomain(entity, location, schedules, images, contents, socials, categories);
+            })
+            .toList();
     }
 
     @Override

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupPortAdapter.java
@@ -66,7 +66,7 @@ public class PopupPortAdapter implements PopupPort {
     }
 
     public List<Popup> findByQuery(PopupQuery query) {
-        var pageable = PageRequest.of(0, query.size());
+        var pageable = PageRequest.of(0, query.size() + 1);
 
         List<PopupEntity> popupEntities = popupJpaRepository.findFilteredPopups(
             query.popupId(),

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/PopupPortAdapter.java
@@ -66,7 +66,7 @@ public class PopupPortAdapter implements PopupPort {
     }
 
     public List<Popup> findByQuery(PopupQuery query) {
-        var pageable = PageRequest.of(query.page() - 1, query.size());
+        var pageable = PageRequest.of(0, query.size());
 
         List<PopupEntity> popupEntities = popupJpaRepository.findFilteredPopups(
             query.popupId(),
@@ -75,6 +75,7 @@ public class PopupPortAdapter implements PopupPort {
             query.types().isEmpty() ? null : query.types(),
             query.categories().isEmpty() ? null : query.categories(),
             query.region1DepthName(),
+            query.lastPopupId(),
             pageable
         );
 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
@@ -27,8 +27,7 @@ public interface PopupJpaRepository extends JpaRepository<PopupEntity, Long> {
     @Query("""
         SELECT p FROM PopupEntity p
         WHERE (:popupId IS NULL OR p.id = :popupId)
-        AND (:startDate IS NULL OR p.startDate >= :startDate)
-        AND (:endDate IS NULL OR p.endDate <= :endDate)
+        AND ((:startDate IS NULL OR :endDate IS NULL) OR (p.endDate >= :startDate AND p.startDate <= :endDate))
         AND (:types IS NULL OR p.type IN :types)
         AND EXISTS (
             SELECT 1 FROM PopupCategoryEntity c

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
@@ -37,7 +37,8 @@ public interface PopupJpaRepository extends JpaRepository<PopupEntity, Long> {
             SELECT 1 FROM PopupLocationEntity l
             WHERE l.id = p.popupLocationId AND (:region1DepthName IS NULL OR l.region1DepthName = :region1DepthName)
         )
-        ORDER BY p.startDate ASC
+        AND (:lastPopupId IS NULL OR p.id > :lastPopupId)
+        ORDER BY p.startDate ASC, p.id ASC
     """)
     List<PopupEntity> findFilteredPopups(
         @Param("popupId") Long popupId,
@@ -46,6 +47,7 @@ public interface PopupJpaRepository extends JpaRepository<PopupEntity, Long> {
         @Param("types") List<String> types,
         @Param("categories") List<String> categories,
         @Param("region1DepthName") String region1DepthName,
+        @Param("lastPopupId") Long lastPopupId,
         Pageable pageable
     );
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
@@ -37,6 +37,7 @@ public interface PopupJpaRepository extends JpaRepository<PopupEntity, Long> {
             SELECT 1 FROM PopupLocationEntity l
             WHERE l.id = p.popupLocationId AND (:region1DepthName IS NULL OR l.region1DepthName = :region1DepthName)
         )
+        ORDER BY p.startDate ASC
     """)
     List<PopupEntity> findFilteredPopups(
         @Param("popupId") Long popupId,

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/PopupJpaRepository.java
@@ -1,10 +1,14 @@
 package com.example.demo.infrastructure.persistence.repository;
 
 import com.example.demo.infrastructure.persistence.entity.popup.PopupEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 /**
  * PopupEntity를 위한 Spring Data JPA Repository.
@@ -19,4 +23,29 @@ public interface PopupJpaRepository extends JpaRepository<PopupEntity, Long> {
      * @return 팝업 엔티티
      */
     Optional<PopupEntity> findById(Long id);
+
+    @Query("""
+        SELECT p FROM PopupEntity p
+        WHERE (:popupId IS NULL OR p.id = :popupId)
+        AND (:startDate IS NULL OR p.startDate >= :startDate)
+        AND (:endDate IS NULL OR p.endDate <= :endDate)
+        AND (:types IS NULL OR p.type IN :types)
+        AND EXISTS (
+            SELECT 1 FROM PopupCategoryEntity c
+            WHERE c.popupId = p.id AND (:categories IS NULL OR c.name IN :categories)
+        )
+        AND EXISTS (
+            SELECT 1 FROM PopupLocationEntity l
+            WHERE l.id = p.popupLocationId AND (:region1DepthName IS NULL OR l.region1DepthName = :region1DepthName)
+        )
+    """)
+    List<PopupEntity> findFilteredPopups(
+        @Param("popupId") Long popupId,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate,
+        @Param("types") List<String> types,
+        @Param("categories") List<String> categories,
+        @Param("region1DepthName") String region1DepthName,
+        Pageable pageable
+    );
 } 

--- a/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
@@ -1,8 +1,12 @@
 package com.example.demo.presentation.controller;
 
 import com.example.demo.application.dto.PopupDetailResponse;
+import com.example.demo.application.dto.popup.PopupFilterRequest;
+import com.example.demo.application.dto.popup.PopupSummaryResponse;
 import com.example.demo.application.service.PopupService;
 import com.example.demo.presentation.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class PopupController {
 
     private final PopupService popupService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PopupSummaryResponse>>> getPopups(@Valid PopupFilterRequest request){
+        List<PopupSummaryResponse> popups = popupService.getFilteredPopups(request);
+        return ResponseEntity.ok(new ApiResponse<>("팝업 상세 조회가 성공했습니다.", popups));
+    }
 
     @GetMapping("/{popupId}")
     public ResponseEntity<ApiResponse<PopupDetailResponse>> getPopupDetail(@PathVariable Long popupId) {

--- a/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
@@ -3,6 +3,7 @@ package com.example.demo.presentation.controller;
 import com.example.demo.application.dto.PopupDetailResponse;
 import com.example.demo.application.dto.popup.PopupFilterRequest;
 import com.example.demo.application.dto.popup.PopupSummaryResponse;
+import com.example.demo.application.dto.popup.PopupCursorResponse;
 import com.example.demo.application.service.PopupService;
 import com.example.demo.presentation.ApiResponse;
 import jakarta.validation.Valid;
@@ -22,9 +23,9 @@ public class PopupController {
     private final PopupService popupService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<PopupSummaryResponse>>> getPopups(@Valid PopupFilterRequest request){
-        List<PopupSummaryResponse> popups = popupService.getFilteredPopups(request);
-        return ResponseEntity.ok(new ApiResponse<>("팝업 목록 조회에 성공했습니다.", popups));
+    public ResponseEntity<ApiResponse<PopupCursorResponse>> getPopups(@Valid PopupFilterRequest request){
+        PopupCursorResponse response = popupService.getFilteredPopups(request);
+        return ResponseEntity.ok(new ApiResponse<>("팝업 목록 조회에 성공했습니다.", response));
     }
 
     @GetMapping("/{popupId}")

--- a/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
@@ -24,7 +24,7 @@ public class PopupController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<PopupSummaryResponse>>> getPopups(@Valid PopupFilterRequest request){
         List<PopupSummaryResponse> popups = popupService.getFilteredPopups(request);
-        return ResponseEntity.ok(new ApiResponse<>("팝업 상세 조회가 성공했습니다.", popups));
+        return ResponseEntity.ok(new ApiResponse<>("팝업 목록 조회에 성공했습니다.", popups));
     }
 
     @GetMapping("/{popupId}")

--- a/backend/src/test/java/com/example/demo/application/service/WaitingServiceTest.java
+++ b/backend/src/test/java/com/example/demo/application/service/WaitingServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.demo.application.service;
 
 import com.example.demo.application.dto.popup.LocationResponse;
+import com.example.demo.application.dto.popup.PopupSummaryResponse;
 import com.example.demo.application.dto.waiting.*;
 import com.example.demo.application.mapper.WaitingDtoMapper;
 import com.example.demo.domain.model.DateRange;
@@ -316,7 +317,7 @@ class WaitingServiceTest {
 
             List<Waiting> waitings = List.of(waiting1, waiting2);
 
-            PopupDtoForWaitingResponse popupDto1 = new PopupDtoForWaitingResponse(
+            PopupSummaryResponse popupDto1 = new PopupSummaryResponse(
                     1L, "테스트 팝업", "thumbnail1.jpg",
                     new LocationResponse("서울시 강남구", "서울특별시", "강남구", "역삼동", 127.0012, 37.5665),
                     5L, "6월 10일 ~ 6월 20일"
@@ -326,7 +327,7 @@ class WaitingServiceTest {
                     1L, 1, "RESERVED", "홍길동", 2, "hong@example.com", popupDto1
             );
 
-            PopupDtoForWaitingResponse popupDto2 = new PopupDtoForWaitingResponse(
+            PopupSummaryResponse popupDto2 = new PopupSummaryResponse(
                     1L, "테스트 팝업", "thumbnail1.jpg",
                     new LocationResponse("서울시 강남구", "서울특별시", "강남구", "역삼동", 127.0012, 37.5665),
                     5L, "6월 10일 ~ 6월 20일"
@@ -368,14 +369,14 @@ class WaitingServiceTest {
 
             List<Waiting> waitings = List.of(waiting1, waiting2);
 
-            PopupDtoForWaitingResponse popupDto1 = new PopupDtoForWaitingResponse(
+            PopupSummaryResponse popupDto1 = new PopupSummaryResponse(
                     1L, "테스트 팝업", "thumbnail1.jpg",
                     new LocationResponse("서울시 강남구", "서울특별시", "강남구", "역삼동", 127.0012, 37.5665),
                     5L, "6월 10일 ~ 6월 20일"
             );
             WaitingResponse waitingResponse1 = new WaitingResponse(1L, 1, "RESERVED", "홍길동", 2, "hong@example.com", popupDto1);
 
-            PopupDtoForWaitingResponse popupDto2 = new PopupDtoForWaitingResponse(
+            PopupSummaryResponse popupDto2 = new PopupSummaryResponse(
                     1L, "테스트 팝업", "thumbnail1.jpg",
                     new LocationResponse("서울시 강남구", "서울특별시", "강남구", "역삼동", 127.0012, 37.5665),
                     5L, "6월 10일 ~ 6월 20일"
@@ -443,7 +444,7 @@ class WaitingServiceTest {
 
             List<Waiting> waitings = List.of(waiting);
 
-            PopupDtoForWaitingResponse popupDto = new PopupDtoForWaitingResponse(
+            PopupSummaryResponse popupDto = new PopupSummaryResponse(
                     1L, "테스트 팝업", "thumbnail1.jpg",
                     new LocationResponse("서울시 강남구", "서울특별시", "강남구", "역삼동", 127.0012, 37.5665),
                     5L, "6월 10일 ~ 6월 20일"
@@ -485,7 +486,7 @@ class WaitingServiceTest {
 
             List<Waiting> waitings = List.of(waiting);
 
-            PopupDtoForWaitingResponse popupDto = new PopupDtoForWaitingResponse(
+            PopupSummaryResponse popupDto = new PopupSummaryResponse(
                     1L, "테스트 팝업", "thumbnail1.jpg",
                     new LocationResponse("서울시 강남구", "서울특별시", "강남구", "역삼동", 127.0012, 37.5665),
                     5L, "6월 10일 ~ 6월 20일"


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #47 

## 변경사항 설명
이 PR에서 어떤 변경사항이 있었는지 설명해주세요.

- **키워드 검색 조건은 정책이 정확하게 정해지지 않아 배제하고 구현했습니다.**

- 팝업 리스트 조회 API에 커서 기반 페이지네이션 및 다양한 필터링 조건을 적용하였습니다.
- 요청 DTO인 PopupFilterRequest와 응답 DTO인 PopupCursorResponse를 새롭게 정의하였습니다.
- PopupType에 대해 한글 ↔ Enum 매핑 기능(fromKorean())을 추가하여 클라이언트에서 한글로 타입을 요청할 수 있도록 지원했습니다.
- 기존 PopupDtoForWaitingResponse를 PopupSummaryResponse로 통일하여 여러 도메인에서 재사용 가능하도록 정리했습니다.
- Repository 레벨에서 PopupJpaRepository.findFilteredPopups()에 lastPopupId 기반 커서 조건을 추가하고, 서비스 단에서 size + 1 방식으로 hasNext 판별 로직 구현했습니다.

## 일정
- 리뷰 요청 기한: 2025-07-15
- 머지 예정일: 2025-07-15


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: DTO 및 Query 객체의 책임 분리가 적절한지, 커서 기반 구조가 도메인 계층에 침투하지 않았는지 검토 부탁드립니다.
- 성능 관련: 
    * MVP 기준 최소 기능만 우선 구현하였으며, 정렬 조건 추가 및 쿼리 최적화는 이후 리팩토링 단계에서 반영 예정입니다.
    * 카테고리 및 지역은 별도 테이블이지만, 성능상의 이유로 `EXISTS` 서브쿼리 방식으로 구현했습니다.
    * QueryDSL 기반으로 전환을 고려하고 있으나 현재는 JPQL 기반으로 빠르게 MVP를 완성하는 데 초점을 맞췄습니다.
- 보안 관련: 
- 기타: 
## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. '...' 페이지로 이동
2. '....' 버튼 클릭
3. '....' 결과 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?(최종 승인 이후 api 명세 수정 예정)
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.
- 여러가지 필터에 따른 테스트 완료
<img width="1096" height="876" alt="image" src="https://github.com/user-attachments/assets/a6aa6783-d35f-43d5-a2a7-6a3ffc583de6" />

## 추가 정보
추가적인 정보나 컨텍스트가 있다면 여기에 작성해주세요. 