### PR TITLE
Feat/#82 알림 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/application/dto/notification/NotificationListRequest.java
+++ b/backend/src/main/java/com/example/demo/application/dto/notification/NotificationListRequest.java
@@ -1,0 +1,10 @@
+package com.example.demo.application.dto.notification;
+
+public record NotificationListRequest(
+        Long memberId,
+        Integer size,
+        Long lastNotificationId,
+        String readStatus,
+        String sort
+) {
+} 

--- a/backend/src/main/java/com/example/demo/application/dto/notification/NotificationListResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/notification/NotificationListResponse.java
@@ -1,0 +1,10 @@
+package com.example.demo.application.dto.notification;
+
+import java.util.List;
+
+public record NotificationListResponse(
+        List<NotificationResponse> content,
+        Long lastNotificationId,
+        boolean hasNext
+) {
+} 

--- a/backend/src/main/java/com/example/demo/application/dto/notification/NotificationResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/notification/NotificationResponse.java
@@ -1,0 +1,13 @@
+package com.example.demo.application.dto.notification;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long notificationId,
+        String notificationCode,
+        String message,
+        LocalDateTime createdAt,
+        boolean isRead,
+        RelatedResourceResponse relatedResource
+) {
+} 

--- a/backend/src/main/java/com/example/demo/application/dto/notification/RelatedResourceResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/notification/RelatedResourceResponse.java
@@ -1,0 +1,7 @@
+package com.example.demo.application.dto.notification;
+
+public record RelatedResourceResponse(
+        String type,
+        Long id
+) {
+} 

--- a/backend/src/main/java/com/example/demo/application/mapper/NotificationDtoMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/NotificationDtoMapper.java
@@ -1,0 +1,74 @@
+package com.example.demo.application.mapper;
+
+import com.example.demo.application.dto.notification.NotificationListResponse;
+import com.example.demo.application.dto.notification.NotificationResponse;
+import com.example.demo.application.dto.notification.RelatedResourceResponse;
+import com.example.demo.domain.model.CursorResult;
+import com.example.demo.domain.model.notification.DomainEvent;
+import com.example.demo.domain.model.notification.Notification;
+import com.example.demo.domain.model.waiting.Waiting;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class NotificationDtoMapper {
+
+    // 대기 도메인 이벤트 타입별 리소스 변환 전략
+    private static final Map<String, Function<Waiting, RelatedResourceResponse>> WAITING_EVENT_STRATEGIES = Map.of(
+            "REVIEW_REQUEST", waiting -> new RelatedResourceResponse("POPUP", waiting.popup().getId()),
+            "WAITING_CONFIRMED", waiting -> new RelatedResourceResponse("WAITING", waiting.id()),
+            "ENTER_3TEAMS_BEFORE", waiting -> new RelatedResourceResponse("WAITING", waiting.id()),
+            "ENTER_NOW", waiting -> new RelatedResourceResponse("WAITING", waiting.id()),
+            "ENTER_TIME_OVER", waiting -> new RelatedResourceResponse("WAITING", waiting.id())
+    );
+
+    public NotificationListResponse toCursorResponse(CursorResult<Notification> cursorResult) {
+        List<NotificationResponse> content = cursorResult.content().stream()
+                .map(this::toNotificationResponse)
+                .collect(Collectors.toList());
+
+        Long lastNotificationId = content.isEmpty() ? null : content.getLast().notificationId();
+
+        return new NotificationListResponse(
+                content,
+                lastNotificationId,
+                cursorResult.hasNext()
+        );
+    }
+
+    public NotificationResponse toNotificationResponse(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getEvent().getEventType(),
+                notification.getContent(),
+                notification.getCreatedAt(),
+                notification.isRead(),
+                toRelatedResourceResponse(notification.getEvent())
+        );
+    }
+
+    private RelatedResourceResponse toRelatedResourceResponse(DomainEvent<?> event) {
+        Object source = event.getSource();
+        String eventType = event.getEventType();
+
+        return switch (source) { // Java 17의 Pattern Matching Switch 문법
+            case Waiting waiting -> processWaitingEvent(waiting, eventType);
+            default -> throw new IllegalArgumentException(
+                    "지원하지 않는 도메인 이벤트 소스입니다: " + source.getClass().getSimpleName()
+            );
+        };
+    }
+
+    private RelatedResourceResponse processWaitingEvent(Waiting waiting, String eventType) {
+        return Optional.ofNullable(WAITING_EVENT_STRATEGIES.get(eventType))
+                .map(strategy -> strategy.apply(waiting))
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "지원하지 않는 대기 이벤트 타입입니다: " + eventType
+                ));
+    }
+}

--- a/backend/src/main/java/com/example/demo/application/service/NotificationService.java
+++ b/backend/src/main/java/com/example/demo/application/service/NotificationService.java
@@ -1,0 +1,84 @@
+package com.example.demo.application.service;
+
+import com.example.demo.application.dto.notification.NotificationListRequest;
+import com.example.demo.application.dto.notification.NotificationListResponse;
+import com.example.demo.application.mapper.NotificationDtoMapper;
+import com.example.demo.domain.model.CursorResult;
+import com.example.demo.domain.model.notification.Notification;
+import com.example.demo.domain.model.notification.NotificationQuery;
+import com.example.demo.domain.model.notification.NotificationSortOrder;
+import com.example.demo.domain.model.notification.ReadStatus;
+import com.example.demo.domain.port.NotificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationPort notificationPort;
+    private final NotificationDtoMapper notificationDtoMapper;
+
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+    private static final NotificationSortOrder DEFAULT_SORT_ORDER = NotificationSortOrder.TIME_DESC;
+
+    public NotificationListResponse getNotifications(NotificationListRequest request) {
+        int pageSize = validateAndSetPageSize(request.size());
+        
+        ReadStatus status = parseReadStatus(request.readStatus());
+        
+        NotificationSortOrder sortOrder = parseSortOrder(request.sort());
+        
+        NotificationQuery query = NotificationQuery.builder()
+                .memberId(request.memberId())
+                .lastNotificationId(request.lastNotificationId())
+                .readStatus(status)
+                .pageSize(pageSize)
+                .sortOrder(sortOrder)
+                .build();
+        
+        CursorResult<Notification> result = notificationPort.findAllBy(query);
+        
+        return notificationDtoMapper.toCursorResponse(result);
+    }
+
+    private int validateAndSetPageSize(Integer size) {
+        if (size == null) {
+            return DEFAULT_SIZE;
+        }
+        if (size <= 0) {
+            throw new IllegalArgumentException("페이지 크기는 0보다 커야 합니다.");
+        }
+        if (size > MAX_SIZE) {
+            throw new IllegalArgumentException("페이지 크기는 " + MAX_SIZE + "을 초과할 수 없습니다.");
+        }
+        return size;
+    }
+
+    private ReadStatus parseReadStatus(String readStatusStr) {
+        if (readStatusStr == null || "ALL".equalsIgnoreCase(readStatusStr)) {
+            return null; // null이면 전체 조회
+        }
+        
+        try {
+            return ReadStatus.valueOf(readStatusStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 읽음 상태입니다: " + readStatusStr);
+        }
+    }
+
+    private NotificationSortOrder parseSortOrder(String sortStr) {
+        if (sortStr == null) {
+            return DEFAULT_SORT_ORDER;
+        }
+        
+        try {
+            return NotificationSortOrder.valueOf(sortStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 정렬 옵션입니다: " + sortStr);
+        }
+    }
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/CursorResult.java
+++ b/backend/src/main/java/com/example/demo/domain/model/CursorResult.java
@@ -1,0 +1,10 @@
+package com.example.demo.domain.model;
+
+import java.util.List;
+
+//TODO : 현장대기에서도 사용하도록 리팩토링
+public record CursorResult<T>(
+    List<T> content,
+    boolean hasNext
+) {
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/CursorResult.java
+++ b/backend/src/main/java/com/example/demo/domain/model/CursorResult.java
@@ -1,10 +1,15 @@
 package com.example.demo.domain.model;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 //TODO : 현장대기에서도 사용하도록 리팩토링
 public record CursorResult<T>(
-    List<T> content,
-    boolean hasNext
+        List<T> content,
+        boolean hasNext
 ) {
+
+    public Stream<T> stream() {
+        return content.stream();
+    }
 } 

--- a/backend/src/main/java/com/example/demo/domain/model/notification/DomainEvent.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/DomainEvent.java
@@ -1,0 +1,18 @@
+package com.example.demo.domain.model.notification;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class DomainEvent<T> {
+    private final T source;
+    private final LocalDateTime occurredAt;
+
+    protected DomainEvent(T source) {
+        this.source = source;
+        this.occurredAt = LocalDateTime.now();
+    }
+
+    public abstract String getEventType();
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/notification/Notification.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/Notification.java
@@ -1,0 +1,36 @@
+package com.example.demo.domain.model.notification;
+
+import com.example.demo.domain.model.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Notification {
+
+    private final Long id;
+    private final Member member;
+    private final DomainEvent<?> event;
+    private final String content;
+    private NotificationStatus status;
+    private final LocalDateTime createdAt;
+
+    @Builder
+    public Notification(Long id, Member member, DomainEvent<?> event, String content, NotificationStatus status, LocalDateTime createdAt) {
+        this.id = id;
+        this.member = member;
+        this.event = event;
+        this.content = content;
+        this.status = (status == null) ? NotificationStatus.unread() : status;
+        this.createdAt = (createdAt == null) ? LocalDateTime.now() : createdAt;
+    }
+
+    public void read() {
+        this.status = this.status.read();
+    }
+
+    public boolean isRead() {
+        return this.status.isRead();
+    }
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/notification/NotificationQuery.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/NotificationQuery.java
@@ -1,0 +1,24 @@
+package com.example.demo.domain.model.notification;
+
+import com.example.demo.domain.model.notification.ReadStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NotificationQuery {
+
+    private final Long notificationId;
+    private final Long memberId;
+    private final Long lastNotificationId;
+    private final ReadStatus readStatus;
+    private final Integer pageSize;
+
+    @Builder
+    private NotificationQuery(Long notificationId, Long memberId, Long lastNotificationId, ReadStatus readStatus, Integer pageSize) {
+        this.notificationId = notificationId;
+        this.memberId = memberId;
+        this.lastNotificationId = lastNotificationId;
+        this.readStatus = readStatus;
+        this.pageSize = pageSize;
+    }
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/notification/NotificationQuery.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/NotificationQuery.java
@@ -12,13 +12,15 @@ public class NotificationQuery {
     private final Long lastNotificationId;
     private final ReadStatus readStatus;
     private final Integer pageSize;
+    private final NotificationSortOrder sortOrder;
 
     @Builder
-    private NotificationQuery(Long notificationId, Long memberId, Long lastNotificationId, ReadStatus readStatus, Integer pageSize) {
+    private NotificationQuery(Long notificationId, Long memberId, Long lastNotificationId, ReadStatus readStatus, Integer pageSize, NotificationSortOrder sortOrder) {
         this.notificationId = notificationId;
         this.memberId = memberId;
         this.lastNotificationId = lastNotificationId;
         this.readStatus = readStatus;
         this.pageSize = pageSize;
+        this.sortOrder = sortOrder;
     }
 } 

--- a/backend/src/main/java/com/example/demo/domain/model/notification/NotificationSortOrder.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/NotificationSortOrder.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.model.notification;
+
+public enum NotificationSortOrder {
+    /**
+     * 안읽음 우선, 이후 생성 시간 내림차순
+     */
+    UNREAD_FIRST,
+    
+    /**
+     * 생성 시간 내림차순
+     */
+    TIME_DESC
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/notification/NotificationStatus.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/NotificationStatus.java
@@ -1,0 +1,30 @@
+package com.example.demo.domain.model.notification;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public final class NotificationStatus {
+
+    private final ReadStatus status;
+    private final LocalDateTime readAt;
+
+    public static NotificationStatus unread() {
+        return new NotificationStatus(ReadStatus.UNREAD, null);
+    }
+
+    public NotificationStatus read() {
+        if (this.status == ReadStatus.UNREAD) {
+            return new NotificationStatus(ReadStatus.READ, LocalDateTime.now());
+        }
+        return this;
+    }
+
+    public boolean isRead() {
+        return this.status == ReadStatus.READ;
+    }
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/notification/NotificationStatus.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/NotificationStatus.java
@@ -13,6 +13,10 @@ public final class NotificationStatus {
     private final ReadStatus status;
     private final LocalDateTime readAt;
 
+    public static NotificationStatus of(ReadStatus status, LocalDateTime readAt) {
+        return new NotificationStatus(status, readAt);
+    }
+
     public static NotificationStatus unread() {
         return new NotificationStatus(ReadStatus.UNREAD, null);
     }

--- a/backend/src/main/java/com/example/demo/domain/model/notification/ReadStatus.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/ReadStatus.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.model.notification;
+
+public enum ReadStatus {
+    READ,
+    UNREAD
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingDomainEvent.java
+++ b/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingDomainEvent.java
@@ -1,0 +1,20 @@
+package com.example.demo.domain.model.waiting;
+
+import com.example.demo.domain.model.notification.DomainEvent;
+import lombok.Getter;
+
+@Getter
+public class WaitingDomainEvent extends DomainEvent<Waiting> {
+
+    private final WaitingEventType eventType;
+
+    public WaitingDomainEvent(Waiting source, WaitingEventType eventType) {
+        super(source);
+        this.eventType = eventType;
+    }
+
+    @Override
+    public String getEventType() {
+        return eventType.name();
+    }
+} 

--- a/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingEventType.java
+++ b/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingEventType.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.model.waiting;
+
+public enum WaitingEventType {
+    WAITING_CONFIRMED, // 대기 확정
+    ENTER_3TEAMS_BEFORE, // 입장 3팀 전
+    ENTER_NOW, // 입장
+    ENTER_TIME_OVER, // 입장 시간 초과
+    REVIEW_REQUEST // 리뷰 요청
+} 

--- a/backend/src/main/java/com/example/demo/domain/port/NotificationPort.java
+++ b/backend/src/main/java/com/example/demo/domain/port/NotificationPort.java
@@ -1,0 +1,12 @@
+package com.example.demo.domain.port;
+
+import com.example.demo.domain.model.CursorResult;
+import com.example.demo.domain.model.notification.Notification;
+import com.example.demo.domain.model.notification.NotificationQuery;
+
+public interface NotificationPort {
+
+    Notification save(Notification notification);
+
+    CursorResult<Notification> findAllBy(NotificationQuery query);
+} 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/NotificationPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/NotificationPortAdapter.java
@@ -1,0 +1,174 @@
+package com.example.demo.infrastructure.persistence.adapter;
+
+import com.example.demo.domain.model.CursorResult;
+import com.example.demo.domain.model.Member;
+import com.example.demo.domain.model.notification.*;
+import com.example.demo.domain.model.waiting.Waiting;
+import com.example.demo.domain.model.waiting.WaitingDomainEvent;
+import com.example.demo.domain.model.waiting.WaitingEventType;
+import com.example.demo.domain.model.waiting.WaitingQuery;
+import com.example.demo.domain.port.MemberPort;
+import com.example.demo.domain.port.NotificationPort;
+import com.example.demo.domain.port.WaitingPort;
+import com.example.demo.infrastructure.persistence.entity.NotificationEntity;
+import com.example.demo.infrastructure.persistence.mapper.NotificationEntityMapper;
+import com.example.demo.infrastructure.persistence.mapper.NotificationEntityMapper.DomainSpecificMapper;
+import com.example.demo.infrastructure.persistence.mapper.NotificationEntityMapper.SourceEntityKey;
+import com.example.demo.infrastructure.persistence.repository.NotificationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationPortAdapter implements NotificationPort {
+
+    private final NotificationJpaRepository repository;
+    private final NotificationEntityMapper mapper;
+    private final MemberPort memberPort;
+    private final WaitingPort waitingPort;
+
+    // 도메인별 매퍼 (지연 초기화)
+    private DomainSpecificMapper<Waiting> waitingMapper;
+
+    @Override
+    public Notification save(Notification notification) {
+        NotificationEntity entity = mapper.toEntity(notification);
+        NotificationEntity savedEntity = repository.save(entity);
+        return getWaitingMapper().toDomain(savedEntity);
+    }
+
+    @Override
+    public CursorResult<Notification> findAllBy(NotificationQuery query) {
+        List<NotificationEntity> entities = executeQuery(query);
+
+        boolean hasNext = false;
+        if (entities.size() > query.getPageSize()) {
+            entities.removeLast();
+            hasNext = true;
+        }
+
+        List<Notification> notifications = entities.stream()
+                .map(this::entityToDomain)
+                .collect(Collectors.toList());
+
+        return new CursorResult<>(notifications, hasNext);
+    }
+
+    /**
+     * 쿼리 조건에 따라 적절한 Repository 메서드 호출
+     */
+    private List<NotificationEntity> executeQuery(NotificationQuery query) {
+        Long memberId = query.getMemberId();
+        ReadStatus status = query.getReadStatus();
+        Long lastId = query.getLastNotificationId();
+        NotificationSortOrder sortOrder = query.getSortOrder();
+        int limit = query.getPageSize() + 1; // hasNext 판단용
+
+        if (lastId == null) {
+            // 첫 페이지 조회
+            return executeFirstPageQuery(memberId, status, sortOrder, limit);
+        } else {
+            // 다음 페이지 조회 (커서 기반)
+            return executeNextPageQuery(memberId, status, lastId, sortOrder, limit);
+        }
+    }
+
+    /**
+     * 첫 페이지 조회
+     */
+    private List<NotificationEntity> executeFirstPageQuery(Long memberId, ReadStatus status, NotificationSortOrder sortOrder, int limit) {
+        if (status == null) {
+            return switch (sortOrder) {
+                case UNREAD_FIRST -> repository.findByMemberIdOrderByUnreadFirstThenCreatedAtDesc(memberId, limit);
+                case TIME_DESC -> repository.findByMemberIdOrderByCreatedAtDesc(memberId, limit);
+            };
+        } else {
+            return switch (sortOrder) {
+                case UNREAD_FIRST -> repository.findByMemberIdAndStatusOrderByUnreadFirstThenCreatedAtDesc(memberId, status, limit);
+                case TIME_DESC -> repository.findByMemberIdAndStatusOrderByCreatedAtDesc(memberId, status, limit);
+            };
+        }
+    }
+
+    /**
+     * 다음 페이지 조회 (커서 기반)
+     */
+    private List<NotificationEntity> executeNextPageQuery(Long memberId, ReadStatus status, Long lastId, NotificationSortOrder sortOrder, int limit) {
+        if (status == null) {
+            return switch (sortOrder) {
+                case UNREAD_FIRST -> repository.findByMemberIdAndIdLessThanOrderByUnreadFirstThenCreatedAtDesc(memberId, lastId, limit);
+                case TIME_DESC -> repository.findByMemberIdAndIdLessThanOrderByCreatedAtDesc(memberId, lastId, limit);
+            };
+        } else {
+            return switch (sortOrder) {
+                case UNREAD_FIRST -> repository.findByMemberIdAndStatusAndIdLessThanOrderByUnreadFirstThenCreatedAtDesc(memberId, status, lastId, limit);
+                case TIME_DESC -> repository.findByMemberIdAndStatusAndIdLessThanOrderByCreatedAtDesc(memberId, status, lastId, limit);
+            };
+        }
+    }
+
+    /**
+     * 엔티티를 도메인으로 변환 (현재는 Waiting만 지원)
+     */
+    private Notification entityToDomain(NotificationEntity entity) {
+        return switch (entity.getSourceDomain()) {
+            case "Waiting" -> getWaitingMapper().toDomain(entity);
+            default -> throw new IllegalArgumentException(
+                    "지원하지 않는 소스 도메인입니다: " + entity.getSourceDomain()
+            );
+        };
+    }
+
+    /**
+     * Waiting 도메인용 매퍼 (지연 초기화)
+     */
+    private DomainSpecificMapper<Waiting> getWaitingMapper() {
+        if (waitingMapper == null) {
+            waitingMapper = NotificationEntityMapper
+                    .forDomain(Waiting.class)
+                    .memberLoader(this::loadMember)
+                    .sourceEntityLoader(this::loadWaitingEntity)
+                    .domainEventFactory(this::createWaitingEvent)
+                    .build();
+        }
+        return waitingMapper;
+    }
+
+    /**
+     * 회원 정보 로드
+     */
+    private Member loadMember(Long memberId) {
+        return memberPort.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다: " + memberId));
+    }
+
+    /**
+     * Waiting 엔티티 로드
+     * TODO: WaitingPort에 findById 메서드 추가되면 개선 필요
+     */
+    private Waiting loadWaitingEntity(SourceEntityKey key) {
+        if (!"Waiting".equals(key.sourceDomain())) {
+            throw new IllegalArgumentException("Waiting 도메인이 아닙니다: " + key.sourceDomain());
+        }
+
+        // 임시 구현: 모든 대기 정보를 조회해서 필터링
+        // 실제로는 WaitingPort에 findById 메서드가 필요함
+        WaitingQuery query = WaitingQuery.firstPage(null, 1000); // 충분히 큰 사이즈로 조회
+        return waitingPort.findByQuery(query)
+                .stream()
+                .filter(waiting -> waiting.id().equals(key.sourceId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 대기 정보입니다: " + key.sourceId()));
+    }
+
+    /**
+     * Waiting 도메인 이벤트 생성
+     */
+    private DomainEvent<Waiting> createWaitingEvent(NotificationEntityMapper.SourceEventContext<Waiting> context) {
+        WaitingEventType eventType = WaitingEventType.valueOf(context.eventType());
+        return new WaitingDomainEvent(context.source(), eventType);
+    }
+} 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/NotificationPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/NotificationPortAdapter.java
@@ -87,7 +87,8 @@ public class NotificationPortAdapter implements NotificationPort {
             };
         } else {
             return switch (sortOrder) {
-                case UNREAD_FIRST -> repository.findByMemberIdAndStatusOrderByUnreadFirstThenCreatedAtDesc(memberId, status, limit);
+                case UNREAD_FIRST ->
+                        repository.findByMemberIdAndStatusOrderByUnreadFirstThenCreatedAtDesc(memberId, status, limit);
                 case TIME_DESC -> repository.findByMemberIdAndStatusOrderByCreatedAtDesc(memberId, status, limit);
             };
         }
@@ -99,13 +100,16 @@ public class NotificationPortAdapter implements NotificationPort {
     private List<NotificationEntity> executeNextPageQuery(Long memberId, ReadStatus status, Long lastId, NotificationSortOrder sortOrder, int limit) {
         if (status == null) {
             return switch (sortOrder) {
-                case UNREAD_FIRST -> repository.findByMemberIdAndIdLessThanOrderByUnreadFirstThenCreatedAtDesc(memberId, lastId, limit);
+                case UNREAD_FIRST ->
+                        repository.findByMemberIdAndIdLessThanOrderByUnreadFirstThenCreatedAtDesc(memberId, lastId, limit);
                 case TIME_DESC -> repository.findByMemberIdAndIdLessThanOrderByCreatedAtDesc(memberId, lastId, limit);
             };
         } else {
             return switch (sortOrder) {
-                case UNREAD_FIRST -> repository.findByMemberIdAndStatusAndIdLessThanOrderByUnreadFirstThenCreatedAtDesc(memberId, status, lastId, limit);
-                case TIME_DESC -> repository.findByMemberIdAndStatusAndIdLessThanOrderByCreatedAtDesc(memberId, status, lastId, limit);
+                case UNREAD_FIRST ->
+                        repository.findByMemberIdAndStatusAndIdLessThanOrderByUnreadFirstThenCreatedAtDesc(memberId, status, lastId, limit);
+                case TIME_DESC ->
+                        repository.findByMemberIdAndStatusAndIdLessThanOrderByCreatedAtDesc(memberId, status, lastId, limit);
             };
         }
     }
@@ -156,8 +160,9 @@ public class NotificationPortAdapter implements NotificationPort {
 
         // 임시 구현: 모든 대기 정보를 조회해서 필터링
         // 실제로는 WaitingPort에 findById 메서드가 필요함
-        WaitingQuery query = WaitingQuery.firstPage(null, 1000); // 충분히 큰 사이즈로 조회
-        return waitingPort.findByQuery(query)
+        WaitingQuery query = WaitingQuery.firstPage(1000L, 1000); // 충분히 큰 사이즈로 조회
+        List<Waiting> byQuery = waitingPort.findByQuery(query);
+        return byQuery
                 .stream()
                 .filter(waiting -> waiting.id().equals(key.sourceId()))
                 .findFirst()

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/entity/NotificationEntity.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/entity/NotificationEntity.java
@@ -1,0 +1,42 @@
+package com.example.demo.infrastructure.persistence.entity;
+
+import com.example.demo.common.entity.BaseEntity;
+import com.example.demo.domain.model.notification.ReadStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notifications")
+public class NotificationEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private String sourceDomain;
+
+    @Column(nullable = false)
+    private Long sourceId;
+
+    @Column(nullable = false)
+    private String eventType;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReadStatus status;
+
+    private LocalDateTime readAt;
+} 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/NotificationEntityMapper.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/NotificationEntityMapper.java
@@ -1,0 +1,149 @@
+package com.example.demo.infrastructure.persistence.mapper;
+
+import com.example.demo.domain.model.Member;
+import com.example.demo.domain.model.notification.DomainEvent;
+import com.example.demo.domain.model.notification.Notification;
+import com.example.demo.domain.model.notification.NotificationStatus;
+import com.example.demo.domain.model.waiting.Waiting;
+import com.example.demo.infrastructure.persistence.entity.NotificationEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEntityMapper {
+
+    /**
+     * 특정 도메인에 특화된 매퍼 클래스
+     */
+    public static class DomainSpecificMapper<T> {
+        private final Function<Long, Member> memberLoader;
+        private final Function<SourceEntityKey, T> sourceEntityLoader;
+        private final Function<SourceEventContext<T>, DomainEvent<T>> domainEventFactory;
+
+        private DomainSpecificMapper(
+                Function<Long, Member> memberLoader,
+                Function<SourceEntityKey, T> sourceEntityLoader,
+                Function<SourceEventContext<T>, DomainEvent<T>> domainEventFactory
+        ) {
+            this.memberLoader = memberLoader;
+            this.sourceEntityLoader = sourceEntityLoader;
+            this.domainEventFactory = domainEventFactory;
+        }
+
+        /**
+         * 엔티티를 도메인 모델로 변환
+         */
+        public Notification toDomain(NotificationEntity entity) {
+            if (entity == null) return null;
+
+            // 회원 정보 로드
+            Member member = memberLoader.apply(entity.getMemberId());
+
+            // 소스 엔티티 로드
+            SourceEntityKey sourceKey = new SourceEntityKey(entity.getSourceDomain(), entity.getSourceId());
+            T sourceEntity = sourceEntityLoader.apply(sourceKey);
+
+            // 도메인 이벤트 생성
+            SourceEventContext<T> eventContext = new SourceEventContext<>(sourceEntity, entity.getEventType());
+            DomainEvent<T> domainEvent = domainEventFactory.apply(eventContext);
+
+            // 알림 상태 복원
+            NotificationStatus status = NotificationStatus.of(entity.getStatus(), entity.getReadAt());
+
+            return Notification.builder()
+                    .id(entity.getId())
+                    .member(member)
+                    .event(domainEvent)
+                    .content(entity.getContent())
+                    .status(status)
+                    .createdAt(entity.getCreatedAt())
+                    .build();
+        }
+    }
+
+    /**
+     * 도메인별 매퍼 빌더
+     */
+    public static class DomainSpecificMapperBuilder<T> {
+        private Function<Long, Member> memberLoader;
+        private Function<SourceEntityKey, T> sourceEntityLoader;
+        private Function<SourceEventContext<T>, DomainEvent<T>> domainEventFactory;
+
+        public DomainSpecificMapperBuilder<T> memberLoader(Function<Long, Member> memberLoader) {
+            this.memberLoader = memberLoader;
+            return this;
+        }
+
+        public DomainSpecificMapperBuilder<T> sourceEntityLoader(Function<SourceEntityKey, T> sourceEntityLoader) {
+            this.sourceEntityLoader = sourceEntityLoader;
+            return this;
+        }
+
+        public DomainSpecificMapperBuilder<T> domainEventFactory(Function<SourceEventContext<T>, DomainEvent<T>> domainEventFactory) {
+            this.domainEventFactory = domainEventFactory;
+            return this;
+        }
+
+        public DomainSpecificMapper<T> build() {
+            if (memberLoader == null || sourceEntityLoader == null || domainEventFactory == null) {
+                throw new IllegalStateException("모든 필수 함수형 인터페이스가 설정되어야 합니다.");
+            }
+            return new DomainSpecificMapper<>(memberLoader, sourceEntityLoader, domainEventFactory);
+        }
+    }
+
+    /**
+     * 소스 엔티티 식별을 위한 키 클래스
+     */
+    public record SourceEntityKey(String sourceDomain, Long sourceId) {
+    }
+
+    /**
+     * 이벤트 생성을 위한 컨텍스트 클래스
+     */
+    public record SourceEventContext<T>(T source, String eventType) {
+    }
+
+    /**
+     * 특정 도메인에 특화된 매퍼 빌더 생성
+     */
+    public static <T> DomainSpecificMapperBuilder<T> forDomain(Class<T> domainClass) {
+        return new DomainSpecificMapperBuilder<>();
+    }
+
+    /**
+     * 소스 객체에서 ID를 추출하는 헬퍼 메서드
+     */
+    private Long extractSourceId(Object source) {
+        return switch (source) {
+            case Waiting waiting -> waiting.id();
+            default -> throw new IllegalArgumentException(
+                    "지원하지 않는 소스 도메인 타입입니다: " + source.getClass().getSimpleName()
+            );
+        };
+    }
+
+    /**
+     * 도메인 모델을 엔티티로 변환 (변환 로직이 공통적이므로 static 메서드로 유지)
+     */
+    public NotificationEntity toEntity(Notification notification) {
+        if (notification == null) return null;
+
+        DomainEvent<?> event = notification.getEvent();
+        Object source = event.getSource();
+
+        return NotificationEntity.builder()
+                .id(notification.getId())
+                .memberId(notification.getMember().id())
+                .sourceDomain(source.getClass().getSimpleName())
+                .sourceId(extractSourceId(source))
+                .eventType(event.getEventType())
+                .content(notification.getContent())
+                .status(notification.getStatus().getStatus())
+                .readAt(notification.getStatus().getReadAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/NotificationJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/NotificationJpaRepository.java
@@ -1,0 +1,60 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.domain.model.notification.ReadStatus;
+import com.example.demo.infrastructure.persistence.entity.NotificationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface NotificationJpaRepository extends JpaRepository<NotificationEntity, Long> {
+
+    // 1. 첫 페이지 - 전체 조회 (TIME_DESC)
+    @Query("SELECT n FROM NotificationEntity n WHERE n.memberId = :memberId " +
+           "ORDER BY n.createdAt DESC LIMIT :limit")
+    List<NotificationEntity> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") Long memberId, @Param("limit") int limit);
+
+    // 2. 첫 페이지 - 전체 조회 (UNREAD_FIRST)
+    @Query("SELECT n FROM NotificationEntity n WHERE n.memberId = :memberId " +
+           "ORDER BY CASE WHEN n.status = 'UNREAD' THEN 0 ELSE 1 END, n.createdAt DESC LIMIT :limit")
+    List<NotificationEntity> findByMemberIdOrderByUnreadFirstThenCreatedAtDesc(@Param("memberId") Long memberId, @Param("limit") int limit);
+
+    // 3. 첫 페이지 - 상태 필터링 (TIME_DESC)
+    @Query("SELECT n FROM NotificationEntity n WHERE n.memberId = :memberId AND n.status = :status " +
+           "ORDER BY n.createdAt DESC LIMIT :limit")
+    List<NotificationEntity> findByMemberIdAndStatusOrderByCreatedAtDesc(
+            @Param("memberId") Long memberId, @Param("status") ReadStatus status, @Param("limit") int limit);
+
+    // 4. 첫 페이지 - 상태 필터링 (UNREAD_FIRST)
+    @Query("SELECT n FROM NotificationEntity n WHERE n.memberId = :memberId AND n.status = :status " +
+           "ORDER BY CASE WHEN n.status = 'UNREAD' THEN 0 ELSE 1 END, n.createdAt DESC LIMIT :limit")
+    List<NotificationEntity> findByMemberIdAndStatusOrderByUnreadFirstThenCreatedAtDesc(
+            @Param("memberId") Long memberId, @Param("status") ReadStatus status, @Param("limit") int limit);
+
+    // 5. 다음 페이지 - 전체 조회 (TIME_DESC)
+    @Query("SELECT n FROM NotificationEntity n WHERE n.memberId = :memberId AND n.id < :lastNotificationId " +
+           "ORDER BY n.createdAt DESC LIMIT :limit")
+    List<NotificationEntity> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
+            @Param("memberId") Long memberId, @Param("lastNotificationId") Long lastNotificationId, @Param("limit") int limit);
+
+    // 6. 다음 페이지 - 전체 조회 (UNREAD_FIRST)
+    @Query("SELECT n FROM NotificationEntity n WHERE n.memberId = :memberId AND n.id < :lastNotificationId " +
+           "ORDER BY CASE WHEN n.status = 'UNREAD' THEN 0 ELSE 1 END, n.createdAt DESC LIMIT :limit")
+    List<NotificationEntity> findByMemberIdAndIdLessThanOrderByUnreadFirstThenCreatedAtDesc(
+            @Param("memberId") Long memberId, @Param("lastNotificationId") Long lastNotificationId, @Param("limit") int limit);
+
+    // 7. 다음 페이지 - 상태 필터링 (TIME_DESC)
+    @Query("SELECT n FROM NotificationEntity n WHERE n.memberId = :memberId AND n.status = :status AND n.id < :lastNotificationId " +
+           "ORDER BY n.createdAt DESC LIMIT :limit")
+    List<NotificationEntity> findByMemberIdAndStatusAndIdLessThanOrderByCreatedAtDesc(
+            @Param("memberId") Long memberId, @Param("status") ReadStatus status, 
+            @Param("lastNotificationId") Long lastNotificationId, @Param("limit") int limit);
+
+    // 8. 다음 페이지 - 상태 필터링 (UNREAD_FIRST)
+    @Query("SELECT n FROM NotificationEntity n WHERE n.memberId = :memberId AND n.status = :status AND n.id < :lastNotificationId " +
+           "ORDER BY CASE WHEN n.status = 'UNREAD' THEN 0 ELSE 1 END, n.createdAt DESC LIMIT :limit")
+    List<NotificationEntity> findByMemberIdAndStatusAndIdLessThanOrderByUnreadFirstThenCreatedAtDesc(
+            @Param("memberId") Long memberId, @Param("status") ReadStatus status, 
+            @Param("lastNotificationId") Long lastNotificationId, @Param("limit") int limit);
+} 

--- a/backend/src/main/java/com/example/demo/presentation/controller/NotificationController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/NotificationController.java
@@ -1,0 +1,46 @@
+package com.example.demo.presentation.controller;
+
+import com.example.demo.application.dto.notification.NotificationListRequest;
+import com.example.demo.application.dto.notification.NotificationListResponse;
+import com.example.demo.application.service.NotificationService;
+import com.example.demo.presentation.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    /**
+     * 알림 내역 조회
+     * 
+     * @param size 한 번에 조회할 항목 개수 (기본값: 20, 최대값: 100)
+     * @param lastNotificationId 이전 조회 결과의 마지막 notificationId (첫 페이지 조회 시 생략)
+     * @param readStatus 조회할 알림 상태 (READ, UNREAD, ALL - 기본값: ALL)
+     * @param sort 정렬 기준 (UNREAD_FIRST, TIME_DESC - 기본값: TIME_DESC)
+     * @param memberId 임시 파라미터 (실제로는 인증된 사용자 정보에서 추출)
+     * @return 알림 목록 응답
+     */
+    @GetMapping
+    public ApiResponse<NotificationListResponse> getNotifications(
+            @RequestParam(required = false, defaultValue = "20") Integer size,
+            @RequestParam(required = false) Long lastNotificationId,
+            @RequestParam(required = false, defaultValue = "ALL") String readStatus,
+            @RequestParam(required = false, defaultValue = "TIME_DESC") String sort
+    ) {
+        NotificationListRequest request = new NotificationListRequest(
+                1000L,
+                size,
+                lastNotificationId,
+                readStatus,
+                sort
+        );
+
+        NotificationListResponse response = notificationService.getNotifications(request);
+        
+        return new ApiResponse<>("성공", response);
+    }
+} 

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -85,3 +85,33 @@ VALUES (1, 1, 'http://icon.com', 'http://url.com', 1);
 INSERT INTO popup_reviews (id, popup_id, member_id, rating, content)
 VALUES (1, 1, 1000, 4, '좋아요'),
        (2, 1, 1001, 5, '최고예요');
+
+-- ===================================
+-- ✅ [DATA] waiting
+-- ===================================
+
+INSERT INTO waitings (id, popup_id, waiting_person_name, member_id, contact_email, people_count, waiting_number, status, created_at, modified_at)
+VALUES (100, 1, '김테스트', 1000, 'test@test.com', 2, 1, 'WAITING', '2025-06-28T10:00:00', '2025-06-28T10:00:00'),
+       (101, 1, '이테스트', 1001, 'test2@test.com', 1, 2, 'WAITING', '2025-06-28T11:00:00', '2025-06-28T11:00:00'),
+       (102, 1, '박테스트', 1000, 'test@test.com', 3, 3, 'VISITED', '2025-06-28T09:00:00', '2025-06-28T09:00:00');
+
+-- ===================================
+-- ✅ [DATA] notifications
+-- ===================================
+
+INSERT INTO notifications (id, member_id, source_domain, source_id, event_type, content, status, read_at, created_at, modified_at)
+VALUES 
+-- 읽지 않은 알림들 (최신순)
+(500, 1000, 'Waiting', 100, 'ENTER_NOW', '지금 매장으로 입장 부탁드립니다. 즐거운 시간 보내세요!', 'UNREAD', NULL, '2025-06-28T15:30:00', '2025-06-28T15:30:00'),
+(501, 1000, 'Waiting', 100, 'ENTER_3TEAMS_BEFORE', '앞으로 3팀 남았습니다! 순서가 다가오니 매장 근처에서 대기해주세요!', 'UNREAD', NULL, '2025-06-28T15:00:00', '2025-06-28T15:00:00'),
+(502, 1001, 'Waiting', 101, 'WAITING_CONFIRMED', '대기 등록이 완료되었습니다. 대기번호 2번으로 확정되었습니다.', 'UNREAD', NULL, '2025-06-28T14:30:00', '2025-06-28T14:30:00'),
+
+-- 읽은 알림들
+(503, 1000, 'Waiting', 102, 'REVIEW_REQUEST', '오늘 ''무신사 X 나이키 팝업스토어'' 방문은 어떠셨나요? 간단한 리뷰만 남겨주셔도 큰 힘이 됩니다 :)', 'read', '2025-06-28T13:15:00', '2025-06-28T13:00:00', '2025-06-28T13:00:00'),
+(504, 1000, 'Waiting', 100, 'WAITING_CONFIRMED', '대기 등록이 완료되었습니다. 대기번호 1번으로 확정되었습니다.', 'read', '2025-06-28T11:05:00', '2025-06-28T10:05:00', '2025-06-28T10:05:00'),
+(505, 1001, 'Waiting', 101, 'ENTER_TIME_OVER', '입장 시간이 초과되어 대기가 취소되었습니다. 다음 기회에 다시 신청해주세요.', 'read', '2025-06-28T12:00:00', '2025-06-28T11:30:00', '2025-06-28T11:30:00'),
+
+-- 추가 테스트 데이터 (페이징 테스트용)
+(506, 1000, 'Waiting', 102, 'ENTER_3TEAMS_BEFORE', '입장까지 3팀 남았습니다!', 'read', '2025-06-28T09:45:00', '2025-06-28T09:30:00', '2025-06-28T09:30:00'),
+(507, 1001, 'Waiting', 101, 'ENTER_NOW', '지금 입장해주세요!', 'UNREAD', NULL, '2025-06-28T08:00:00', '2025-06-28T08:00:00'),
+(508, 1000, 'Waiting', 100, 'ENTER_TIME_OVER', '입장 시간이 지났습니다.', 'read', '2025-06-28T07:30:00', '2025-06-28T07:00:00', '2025-06-28T07:00:00');

--- a/backend/src/test/java/com/example/demo/infrastructure/persistence/adapter/WaitingPortAdapterTest.java
+++ b/backend/src/test/java/com/example/demo/infrastructure/persistence/adapter/WaitingPortAdapterTest.java
@@ -39,6 +39,9 @@ class WaitingPortAdapterTest {
     @MockitoBean
     private PopupPortAdapter popupPortAdapter;
 
+    @MockitoBean
+    private MemberPortAdapter memberPortAdapter;
+
     private Member member;
     private Popup popup;
 


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #82 

## 변경사항 설명
- 알림 조회 API 구현
  - 현재는 현장 대기에 대해서 알림이 발생하지만, 추후 확장될 여지가 있을 것 같아 여러 도메인의 변경이 알림의 생성을 야기하는 구조로 설계했습니다.
    - 이 부분은 MR 머지 후 알림 생성 로직 작성하면서 더 잘 들어날 것이라 생각됩니다.
   - 테스트를 위해 data.sql 에 현장 대기와 알림 데이터를 넣어두었습니다.  

## 일정
- 리뷰 요청 기한: 2025-07-20
- 머지 예정일: 2025-07-21


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: 

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. '...' 페이지로 이동
2. '....' 버튼 클릭
3. '....' 결과 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [x] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?
