### PR TITLE
(Feat/#96) 카카오 로그인 구현 및 인증설정

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,15 +25,20 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation "io.jsonwebtoken:jjwt-api:0.12.6"
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:0.12.6"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.12.6"
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/demo/application/dto/member/MeResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/member/MeResponse.java
@@ -1,0 +1,19 @@
+package com.example.demo.application.dto.member;
+
+import com.example.demo.domain.model.Member;
+import lombok.Builder;
+
+@Builder
+public record MeResponse(
+    Long id,
+    String name,
+    String email
+) {
+    public static MeResponse from(Member member) {
+        return MeResponse.builder()
+            .id(member.id())
+            .name(member.name())
+            .email(member.email())
+            .build();
+    }
+} 

--- a/backend/src/main/java/com/example/demo/application/dto/oauth/KakaoTokenResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/oauth/KakaoTokenResponse.java
@@ -1,0 +1,12 @@
+package com.example.demo.application.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+    @JsonProperty("token_type") String tokenType,
+    @JsonProperty("access_token") String accessToken,
+    @JsonProperty("expires_in") Integer expiresIn,
+    @JsonProperty("refresh_token") String refreshToken,
+    @JsonProperty("refresh_token_expires_in") Integer refreshTokenExpiresIn,
+    @JsonProperty("scope") String scope
+) {} 

--- a/backend/src/main/java/com/example/demo/application/dto/oauth/KakaoUserInfoResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/oauth/KakaoUserInfoResponse.java
@@ -1,0 +1,32 @@
+package com.example.demo.application.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public record KakaoUserInfoResponse(
+    Long id,
+    @JsonProperty("connected_at") String connectedAt,
+    Map<String, Object> properties,
+    @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+        @JsonProperty("profile_nickname_needs_agreement") Boolean profileNicknameNeedsAgreement,
+        Profile profile,
+        @JsonProperty("email_needs_agreement") Boolean emailNeedsAgreement,
+        @JsonProperty("is_email_valid") Boolean isEmailValid,
+        @JsonProperty("is_email_verified") Boolean isEmailVerified,
+        String email
+    ) {}
+
+    public record Profile(
+        String nickname
+    ) {}
+    
+    public String getNickname() {
+        return this.properties.get("nickname").toString();
+    }
+    
+    public String getEmail() {
+        return this.kakaoAccount.email();
+    }
+} 

--- a/backend/src/main/java/com/example/demo/application/dto/oauth/KakaoUserInfoResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/oauth/KakaoUserInfoResponse.java
@@ -2,6 +2,7 @@ package com.example.demo.application.dto.oauth;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
+import java.util.Optional;
 
 public record KakaoUserInfoResponse(
     Long id,
@@ -23,7 +24,9 @@ public record KakaoUserInfoResponse(
     ) {}
     
     public String getNickname() {
-        return this.properties.get("nickname").toString();
+        return Optional.ofNullable(properties.get("nickname"))
+            .map(Object::toString)
+            .orElse("unknown");
     }
     
     public String getEmail() {

--- a/backend/src/main/java/com/example/demo/application/service/OAuth2Service.java
+++ b/backend/src/main/java/com/example/demo/application/service/OAuth2Service.java
@@ -1,0 +1,100 @@
+package com.example.demo.application.service;
+
+import com.example.demo.application.dto.oauth.KakaoTokenResponse;
+import com.example.demo.application.dto.oauth.KakaoUserInfoResponse;
+import com.example.demo.domain.model.Member;
+import com.example.demo.domain.model.OAuthAccount;
+import com.example.demo.domain.model.OAuthProvider;
+import com.example.demo.domain.port.MemberPort;
+import com.example.demo.domain.port.OAuthAccountPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2Service {
+
+    private final MemberPort memberPort;
+    private final OAuthAccountPort oAuthAccountPort;
+    private final RestTemplate restTemplate = new RestTemplate();
+    
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String kakaoTokenUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String kakaoUserInfoUri;
+
+    @Transactional
+    public Member processKakaoLogin(String authorizationCode) {
+        String accessToken = getKakaoAccessToken(authorizationCode);
+        KakaoUserInfoResponse userInfo = getKakaoUserInfo(accessToken);
+
+        String providerId = userInfo.id().toString();
+        return oAuthAccountPort.findByProviderAndProviderId(OAuthProvider.KAKAO, providerId)
+            .map(oauthAccount -> memberPort.findById(oauthAccount.memberId())
+                .orElseThrow(() -> new IllegalStateException("OAuth 계정과 연결된 회원을 찾을 수 없습니다.")))
+            .orElseGet(() -> {
+                String nickname = userInfo.getNickname();
+                String email = userInfo.getEmail();
+
+                Member newMember = memberPort.save(new Member(null, nickname, email));
+                OAuthAccount newOAuthAccount = new OAuthAccount(null, OAuthProvider.KAKAO, providerId, newMember.id());
+                oAuthAccountPort.save(newOAuthAccount);
+
+                return newMember;
+            });
+    }
+
+    private String getKakaoAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoClientId);
+        params.add("client_secret", kakaoClientSecret);
+        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        KakaoTokenResponse response = restTemplate.postForObject(kakaoTokenUri, request, KakaoTokenResponse.class);
+
+        if (response == null) {
+            throw new IllegalStateException("카카오 토큰 응답을 받지 못했습니다.");
+        }
+        return response.accessToken();
+    }
+
+    private KakaoUserInfoResponse getKakaoUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        
+        HttpEntity<?> request = new HttpEntity<>(headers);
+
+        KakaoUserInfoResponse response = restTemplate.postForObject(kakaoUserInfoUri, request, KakaoUserInfoResponse.class);
+
+        if (response == null) {
+            throw new IllegalStateException("카카오 사용자 정보 응답을 받지 못했습니다.");
+        }
+        return response;
+    }
+} 

--- a/backend/src/main/java/com/example/demo/application/service/OAuth2Service.java
+++ b/backend/src/main/java/com/example/demo/application/service/OAuth2Service.java
@@ -24,7 +24,7 @@ public class OAuth2Service {
 
     private final MemberPort memberPort;
     private final OAuthAccountPort oAuthAccountPort;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
     
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String kakaoClientId;

--- a/backend/src/main/java/com/example/demo/application/service/WaitingService.java
+++ b/backend/src/main/java/com/example/demo/application/service/WaitingService.java
@@ -42,10 +42,8 @@ public class WaitingService {
         Integer nextWaitingNumber = waitingPort.getNextWaitingNumber(request.popupId());
 
         // 3. 회원 정보 조회
-//        Member member = memberPort.findById(request.memberId())
-//                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다: " + request.memberId()));
-
-        Member member = new Member(request.memberId(), "dd", "robin@naver.com");
+        Member member = memberPort.findById(request.memberId())
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다: " + request.memberId()));
 
         // 4. 대기 정보 생성
         Waiting waiting = new Waiting(
@@ -71,9 +69,7 @@ public class WaitingService {
      * 내 방문/예약 내역 조회 (무한 스크롤)
      */
     @Transactional(readOnly = true)
-    public VisitHistoryCursorResponse getVisitHistory(Integer size, Long lastWaitingId, String status) {
-        // TODO: 사용자 인증 확인 (현재는 임시로 memberId = 1 사용)
-        Long memberId = 1L;
+    public VisitHistoryCursorResponse getVisitHistory(Long memberId,Integer size, Long lastWaitingId, String status) {
 
         // 1. 조회 조건 생성
         WaitingQuery query = WaitingQuery.forVisitHistory(memberId, size, lastWaitingId, status);

--- a/backend/src/main/java/com/example/demo/common/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/demo/common/jwt/JwtAuthenticationFilter.java
@@ -28,15 +28,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         
         String token = resolveToken(request);
 
-        if (token != null) {
-            try {
-                Claims claims = jwtTokenProvider.getClaims(token);
-                Authentication authentication = getAuthentication(claims);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            } catch (Exception e) {
-                // 토큰이 유효하지 않은 경우, SecurityContext를 비웁니다.
-                SecurityContextHolder.clearContext();
-            }
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         
         filterChain.doFilter(request, response);
@@ -52,14 +46,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 .findFirst()
                 .map(Cookie::getValue)
                 .orElse(null);
-    }
-    
-    private Authentication getAuthentication(Claims claims) {
-        Long id = claims.get("id", Long.class);
-        String name = claims.get("name", String.class);
-        String email = claims.get("email", String.class);
-        
-        Member member = new Member(id, name, email);
-        return new UsernamePasswordAuthenticationToken(member, null, Collections.emptyList());
     }
 } 

--- a/backend/src/main/java/com/example/demo/common/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/demo/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.example.demo.common.jwt;
+
+import com.example.demo.domain.model.Member;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        
+        String token = resolveToken(request);
+
+        if (token != null) {
+            try {
+                Claims claims = jwtTokenProvider.getClaims(token);
+                Authentication authentication = getAuthentication(claims);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                // 토큰이 유효하지 않은 경우, SecurityContext를 비웁니다.
+                SecurityContextHolder.clearContext();
+            }
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+    
+    private String resolveToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        return Arrays.stream(cookies)
+                .filter(cookie -> "accessToken".equals(cookie.getName()))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElse(null);
+    }
+    
+    private Authentication getAuthentication(Claims claims) {
+        Long id = claims.get("id", Long.class);
+        String name = claims.get("name", String.class);
+        String email = claims.get("email", String.class);
+        
+        Member member = new Member(id, name, email);
+        return new UsernamePasswordAuthenticationToken(member, null, Collections.emptyList());
+    }
+} 

--- a/backend/src/main/java/com/example/demo/common/jwt/JwtProperties.java
+++ b/backend/src/main/java/com/example/demo/common/jwt/JwtProperties.java
@@ -1,0 +1,9 @@
+package com.example.demo.common.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "custom.jwt.access-token")
+public record JwtProperties(
+    String secret,
+    Long expirationSeconds
+) {} 

--- a/backend/src/main/java/com/example/demo/common/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/example/demo/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,46 @@
+package com.example.demo.common.jwt;
+
+import com.example.demo.domain.model.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final Long expirationSeconds;
+
+    public JwtTokenProvider(JwtProperties jwtProperties) {
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+        this.expirationSeconds = jwtProperties.expirationSeconds();
+    }
+
+    public String createToken(Member member) {
+        Instant now = Instant.now();
+        Instant expiry = now.plusSeconds(expirationSeconds);
+
+        return Jwts.builder()
+                .claim("id", member.id())
+                .claim("name", member.name())
+                .claim("email", member.email())
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expiry))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+} 

--- a/backend/src/main/java/com/example/demo/common/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/example/demo/common/jwt/JwtTokenProvider.java
@@ -41,6 +41,7 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
             .subject(userPrincipal.getId().toString())
+            .claim("email", userPrincipal.getEmail())
             .issuedAt(now)
             .expiration(expiryDate)
             .signWith(key)
@@ -50,9 +51,10 @@ public class JwtTokenProvider {
     public Authentication getAuthentication(String token) {
         Claims claims = parseClaims(token);
         Long userId = Long.parseLong(claims.getSubject());
+        String email = claims.get("email", String.class);
 
         Collection<? extends GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
-        UserPrincipal principal = new UserPrincipal(userId, authorities);
+        UserPrincipal principal = new UserPrincipal(userId, email, authorities);
 
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
     }

--- a/backend/src/main/java/com/example/demo/common/security/UserPrincipal.java
+++ b/backend/src/main/java/com/example/demo/common/security/UserPrincipal.java
@@ -1,0 +1,59 @@
+package com.example.demo.common.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class UserPrincipal implements UserDetails {
+
+    private final Long id;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public UserPrincipal(Long id, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(Long id) {
+        return new UserPrincipal(id, Collections.emptyList());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.id.toString();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+} 

--- a/backend/src/main/java/com/example/demo/common/security/UserPrincipal.java
+++ b/backend/src/main/java/com/example/demo/common/security/UserPrincipal.java
@@ -11,15 +11,17 @@ import java.util.Collections;
 public class UserPrincipal implements UserDetails {
 
     private final Long id;
+    private final String email;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public UserPrincipal(Long id, Collection<? extends GrantedAuthority> authorities) {
+    public UserPrincipal(Long id, String email, Collection<? extends GrantedAuthority> authorities) {
         this.id = id;
+        this.email = email;
         this.authorities = authorities;
     }
 
-    public static UserPrincipal create(Long id) {
-        return new UserPrincipal(id, Collections.emptyList());
+    public static UserPrincipal create(Long id, String email) {
+        return new UserPrincipal(id, email, Collections.emptyList());
     }
 
     @Override
@@ -34,7 +36,7 @@ public class UserPrincipal implements UserDetails {
 
     @Override
     public String getUsername() {
-        return this.id.toString();
+        return this.email;
     }
 
     @Override

--- a/backend/src/main/java/com/example/demo/common/util/CookieUtils.java
+++ b/backend/src/main/java/com/example/demo/common/util/CookieUtils.java
@@ -1,0 +1,17 @@
+package com.example.demo.common.util;
+
+import jakarta.servlet.http.Cookie;
+
+public class CookieUtils {
+
+    public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+
+    public static Cookie createAccessTokenCookie(String token, long maxAgeSeconds) {
+        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge((int) maxAgeSeconds);
+        return cookie;
+    }
+} 

--- a/backend/src/main/java/com/example/demo/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/example/demo/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+} 

--- a/backend/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.example.demo.config;
+
+import com.example.demo.common.jwt.JwtAuthenticationFilter;
+import com.example.demo.common.jwt.JwtProperties;
+import com.example.demo.common.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableConfigurationProperties(JwtProperties.class)
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            //h2 확인을 위한 설정 TODO: MySQL 연결시 삭제
+            .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/",
+                    "/error",
+                    "/favicon.ico",
+                    "/h2-console/**",
+                    "/oauth/**" // /oauth/kakao/callback 등을 허용
+                ).permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/popups/**").permitAll() // GET 요청만 허용
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+} 

--- a/backend/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -23,7 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
-
+    // TODO: 아키텍처 리팩토링 https://github.com/JECT-Study/JECT-3th-6team/pull/99
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http

--- a/backend/src/main/java/com/example/demo/domain/model/OAuthAccount.java
+++ b/backend/src/main/java/com/example/demo/domain/model/OAuthAccount.java
@@ -1,0 +1,8 @@
+package com.example.demo.domain.model;
+
+public record OAuthAccount(
+    Long id,
+    OAuthProvider provider,
+    String providerId,
+    Long memberId
+) {} 

--- a/backend/src/main/java/com/example/demo/domain/model/OAuthProvider.java
+++ b/backend/src/main/java/com/example/demo/domain/model/OAuthProvider.java
@@ -1,0 +1,12 @@
+package com.example.demo.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthProvider {
+    KAKAO("kakao");
+
+    private final String registrationId;
+} 

--- a/backend/src/main/java/com/example/demo/domain/port/MemberPort.java
+++ b/backend/src/main/java/com/example/demo/domain/port/MemberPort.java
@@ -17,4 +17,12 @@ public interface MemberPort {
      * @return 회원 정보 (없으면 empty)
      */
     Optional<Member> findById(Long id);
+
+    /**
+     * 회원 정보를 저장(생성 또는 수정)한다.
+     *
+     * @param member 회원 정보
+     * @return 저장된 회원 정보
+     */
+    Member save(Member member);
 } 

--- a/backend/src/main/java/com/example/demo/domain/port/OAuthAccountPort.java
+++ b/backend/src/main/java/com/example/demo/domain/port/OAuthAccountPort.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.port;
+
+import com.example.demo.domain.model.OAuthAccount;
+import com.example.demo.domain.model.OAuthProvider;
+
+import java.util.Optional;
+
+public interface OAuthAccountPort {
+
+    Optional<OAuthAccount> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+
+    OAuthAccount save(OAuthAccount oAuthAccount);
+} 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/MemberPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/MemberPortAdapter.java
@@ -24,4 +24,11 @@ public class MemberPortAdapter implements MemberPort {
         return memberJpaRepository.findById(id)
                 .map(memberEntityMapper::toDomain);
     }
+
+    @Override
+    public Member save(Member member) {
+        var entity = memberEntityMapper.toEntity(member);
+        var savedEntity = memberJpaRepository.save(entity);
+        return memberEntityMapper.toDomain(savedEntity);
+    }
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/OAuthAccountPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/OAuthAccountPortAdapter.java
@@ -1,0 +1,32 @@
+package com.example.demo.infrastructure.persistence.adapter;
+
+import com.example.demo.domain.model.OAuthAccount;
+import com.example.demo.domain.model.OAuthProvider;
+import com.example.demo.domain.port.OAuthAccountPort;
+import com.example.demo.infrastructure.persistence.mapper.OAuthAccountEntityMapper;
+import com.example.demo.infrastructure.persistence.repository.OAuthAccountJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OAuthAccountPortAdapter implements OAuthAccountPort {
+
+    private final OAuthAccountJpaRepository oAuthAccountJpaRepository;
+    private final OAuthAccountEntityMapper oAuthAccountEntityMapper;
+
+    @Override
+    public Optional<OAuthAccount> findByProviderAndProviderId(OAuthProvider provider, String providerId) {
+        return oAuthAccountJpaRepository.findByProviderAndProviderId(provider, providerId)
+            .map(oAuthAccountEntityMapper::toDomain);
+    }
+
+    @Override
+    public OAuthAccount save(OAuthAccount oAuthAccount) {
+        var entity = oAuthAccountEntityMapper.toEntity(oAuthAccount);
+        var savedEntity = oAuthAccountJpaRepository.save(entity);
+        return oAuthAccountEntityMapper.toDomain(savedEntity);
+    }
+} 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/entity/OAuthAccountEntity.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/entity/OAuthAccountEntity.java
@@ -1,0 +1,39 @@
+package com.example.demo.infrastructure.persistence.entity;
+
+import com.example.demo.domain.model.OAuthProvider;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "oauth_accounts")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthAccountEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false)
+    private OAuthProvider provider;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+} 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/MemberEntityMapper.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/MemberEntityMapper.java
@@ -23,4 +23,18 @@ public class MemberEntityMapper {
                 entity.getEmail()
         );
     }
+
+    /**
+     * Member 도메인 모델을 MemberEntity로 변환한다.
+     *
+     * @param domain Member 도메인 모델
+     * @return MemberEntity
+     */
+    public MemberEntity toEntity(Member domain) {
+        return MemberEntity.builder()
+            .id(domain.id())
+            .name(domain.name())
+            .email(domain.email())
+            .build();
+    }
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/OAuthAccountEntityMapper.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/OAuthAccountEntityMapper.java
@@ -1,0 +1,27 @@
+package com.example.demo.infrastructure.persistence.mapper;
+
+import com.example.demo.domain.model.OAuthAccount;
+import com.example.demo.infrastructure.persistence.entity.OAuthAccountEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuthAccountEntityMapper {
+
+    public OAuthAccount toDomain(OAuthAccountEntity entity) {
+        return new OAuthAccount(
+            entity.getId(),
+            entity.getProvider(),
+            entity.getProviderId(),
+            entity.getMemberId()
+        );
+    }
+
+    public OAuthAccountEntity toEntity(OAuthAccount domain) {
+        return OAuthAccountEntity.builder()
+            .id(domain.id())
+            .provider(domain.provider())
+            .providerId(domain.providerId())
+            .memberId(domain.memberId())
+            .build();
+    }
+} 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/OAuthAccountJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/OAuthAccountJpaRepository.java
@@ -1,0 +1,14 @@
+package com.example.demo.infrastructure.persistence.repository;
+
+import com.example.demo.domain.model.OAuthProvider;
+import com.example.demo.infrastructure.persistence.entity.OAuthAccountEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OAuthAccountJpaRepository extends JpaRepository<OAuthAccountEntity, Long> {
+
+    Optional<OAuthAccountEntity> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+} 

--- a/backend/src/main/java/com/example/demo/presentation/controller/MemberController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.example.demo.presentation.controller;
+
+import com.example.demo.application.dto.member.MeResponse;
+import com.example.demo.domain.model.Member;
+import com.example.demo.presentation.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MemberController {
+
+    @GetMapping("/me")
+    public ApiResponse<MeResponse> getMe(@AuthenticationPrincipal Member member) {
+        if (member == null) {
+            // 이 경우는 JwtAuthenticationFilter에서 뭔가 잘못되었을 때 발생할 수 있습니다.
+            // 혹은 토큰 없이 접근했을 때 (이론상 SecurityConfig에서 차단됨)
+            throw new IllegalStateException("인증된 사용자 정보를 가져올 수 없습니다.");
+        }
+        return new ApiResponse<>("사용자 정보 조회 성공", MeResponse.from(member));
+    }
+} 

--- a/backend/src/main/java/com/example/demo/presentation/controller/MemberController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/MemberController.java
@@ -1,7 +1,9 @@
 package com.example.demo.presentation.controller;
 
 import com.example.demo.application.dto.member.MeResponse;
+import com.example.demo.common.security.UserPrincipal;
 import com.example.demo.domain.model.Member;
+import com.example.demo.domain.port.MemberPort;
 import com.example.demo.presentation.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,13 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
 
+    private final MemberPort memberPort;
+
     @GetMapping("/me")
-    public ApiResponse<MeResponse> getMe(@AuthenticationPrincipal Member member) {
-        if (member == null) {
-            // 이 경우는 JwtAuthenticationFilter에서 뭔가 잘못되었을 때 발생할 수 있습니다.
-            // 혹은 토큰 없이 접근했을 때 (이론상 SecurityConfig에서 차단됨)
+    public ApiResponse<MeResponse> getMe(@AuthenticationPrincipal UserPrincipal principal) {
+        if (principal == null) {
             throw new IllegalStateException("인증된 사용자 정보를 가져올 수 없습니다.");
         }
+        Member member = memberPort.findById(principal.getId())
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + principal.getId()));
         return new ApiResponse<>("사용자 정보 조회 성공", MeResponse.from(member));
     }
 } 

--- a/backend/src/main/java/com/example/demo/presentation/controller/NotificationController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/NotificationController.java
@@ -3,8 +3,10 @@ package com.example.demo.presentation.controller;
 import com.example.demo.application.dto.notification.NotificationListRequest;
 import com.example.demo.application.dto.notification.NotificationListResponse;
 import com.example.demo.application.service.NotificationService;
+import com.example.demo.common.security.UserPrincipal;
 import com.example.demo.presentation.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -29,10 +31,11 @@ public class NotificationController {
             @RequestParam(required = false, defaultValue = "20") Integer size,
             @RequestParam(required = false) Long lastNotificationId,
             @RequestParam(required = false, defaultValue = "ALL") String readStatus,
-            @RequestParam(required = false, defaultValue = "TIME_DESC") String sort
+            @RequestParam(required = false, defaultValue = "TIME_DESC") String sort,
+            @AuthenticationPrincipal UserPrincipal principal
     ) {
         NotificationListRequest request = new NotificationListRequest(
-                1000L,
+                principal.getId(),
                 size,
                 lastNotificationId,
                 readStatus,

--- a/backend/src/main/java/com/example/demo/presentation/controller/OAuthController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/OAuthController.java
@@ -3,11 +3,14 @@ package com.example.demo.presentation.controller;
 import com.example.demo.application.service.OAuth2Service;
 import com.example.demo.common.jwt.JwtProperties;
 import com.example.demo.common.jwt.JwtTokenProvider;
+import com.example.demo.common.security.UserPrincipal;
 import com.example.demo.domain.model.Member;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,7 +34,11 @@ public class OAuthController {
     @GetMapping("/callback")
     public void kakaoCallback(@RequestParam String code, @RequestParam String state, HttpServletResponse response) throws IOException {
         Member member = oAuth2Service.processKakaoLogin(code);
-        String accessToken = jwtTokenProvider.createToken(member);
+        
+        UserPrincipal principal = UserPrincipal.create(member.id());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        
+        String accessToken = jwtTokenProvider.createToken(authentication);
         
         response.addCookie(createAccessTokenCookie(accessToken));
         

--- a/backend/src/main/java/com/example/demo/presentation/controller/OAuthController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/OAuthController.java
@@ -1,0 +1,53 @@
+package com.example.demo.presentation.controller;
+
+import com.example.demo.application.service.OAuth2Service;
+import com.example.demo.common.jwt.JwtProperties;
+import com.example.demo.common.jwt.JwtTokenProvider;
+import com.example.demo.domain.model.Member;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Controller
+@RequestMapping("/oauth/kakao")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuth2Service oAuth2Service;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+
+    @Value("${custom.app.frontend-url}")
+    private String frontendUrl;
+    
+    @GetMapping("/callback")
+    public void kakaoCallback(@RequestParam String code, @RequestParam String state, HttpServletResponse response) throws IOException {
+        Member member = oAuth2Service.processKakaoLogin(code);
+        String accessToken = jwtTokenProvider.createToken(member);
+        
+        response.addCookie(createAccessTokenCookie(accessToken));
+        
+        String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl)
+                .path(state)
+                .build()
+                .toUriString();
+        response.sendRedirect(redirectUrl);
+    }
+    
+    private Cookie createAccessTokenCookie(String accessToken) {
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true); // HTTPS 환경에서만 전송
+        cookie.setPath("/");
+        cookie.setMaxAge(jwtProperties.expirationSeconds().intValue());
+        return cookie;
+    }
+} 

--- a/backend/src/main/java/com/example/demo/presentation/controller/OAuthController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/OAuthController.java
@@ -1,21 +1,15 @@
 package com.example.demo.presentation.controller;
 
 import com.example.demo.application.service.OAuth2Service;
-import com.example.demo.common.jwt.JwtProperties;
-import com.example.demo.common.jwt.JwtTokenProvider;
-import com.example.demo.common.security.UserPrincipal;
 import com.example.demo.domain.model.Member;
-import jakarta.servlet.http.Cookie;
+import com.example.demo.presentation.controller.handler.OAuth2SuccessHandler;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
@@ -25,8 +19,7 @@ import java.io.IOException;
 public class OAuthController {
 
     private final OAuth2Service oAuth2Service;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final JwtProperties jwtProperties;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Value("${custom.app.frontend-url}")
     private String frontendUrl;
@@ -34,27 +27,6 @@ public class OAuthController {
     @GetMapping("/callback")
     public void kakaoCallback(@RequestParam String code, @RequestParam String state, HttpServletResponse response) throws IOException {
         Member member = oAuth2Service.processKakaoLogin(code);
-        
-        UserPrincipal principal = UserPrincipal.create(member.id());
-        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
-        
-        String accessToken = jwtTokenProvider.createToken(authentication);
-        
-        response.addCookie(createAccessTokenCookie(accessToken));
-        
-        String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl)
-                .path(state)
-                .build()
-                .toUriString();
-        response.sendRedirect(redirectUrl);
-    }
-    
-    private Cookie createAccessTokenCookie(String accessToken) {
-        Cookie cookie = new Cookie("accessToken", accessToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true); // HTTPS 환경에서만 전송
-        cookie.setPath("/");
-        cookie.setMaxAge(jwtProperties.expirationSeconds().intValue());
-        return cookie;
+        oAuth2SuccessHandler.onAuthenticationSuccess(response, member, state, frontendUrl);
     }
 } 

--- a/backend/src/main/java/com/example/demo/presentation/controller/OAuthController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/OAuthController.java
@@ -2,16 +2,16 @@ package com.example.demo.presentation.controller;
 
 import com.example.demo.application.service.OAuth2Service;
 import com.example.demo.domain.model.Member;
+import com.example.demo.presentation.controller.handler.OAuth2FailureHandler;
 import com.example.demo.presentation.controller.handler.OAuth2SuccessHandler;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import java.io.IOException;
 
 @Controller
 @RequestMapping("/oauth/kakao")
@@ -20,13 +20,27 @@ public class OAuthController {
 
     private final OAuth2Service oAuth2Service;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
 
     @Value("${custom.app.frontend-url}")
     private String frontendUrl;
-    
+
     @GetMapping("/callback")
-    public void kakaoCallback(@RequestParam String code, @RequestParam String state, HttpServletResponse response) throws IOException {
-        Member member = oAuth2Service.processKakaoLogin(code);
-        oAuth2SuccessHandler.onAuthenticationSuccess(response, member, state, frontendUrl);
+    public void kakaoCallback(@RequestParam(required = false) String code,
+        @RequestParam(required = false) String error,
+        @RequestParam String state,
+        HttpServletResponse response) throws IOException {
+
+        if (error != null) {
+            oAuth2FailureHandler.handleFailure(response, new IllegalStateException("OAuth2 error param received: " + error));
+            return;
+        }
+
+        try {
+            Member member = oAuth2Service.processKakaoLogin(code);
+            oAuth2SuccessHandler.onAuthenticationSuccess(response, member, state, frontendUrl);
+        } catch (Exception e) {
+            oAuth2FailureHandler.handleFailure(response, e);
+        }
     }
-} 
+}

--- a/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/PopupController.java
@@ -1,20 +1,22 @@
 package com.example.demo.presentation.controller;
 
 import com.example.demo.application.dto.PopupDetailResponse;
+import com.example.demo.application.dto.popup.PopupCursorResponse;
+import com.example.demo.application.dto.popup.PopupFilterRequest;
 import com.example.demo.application.dto.popup.PopupMapRequest;
 import com.example.demo.application.dto.popup.PopupMapResponse;
-import com.example.demo.application.dto.popup.PopupFilterRequest;
-import com.example.demo.application.dto.popup.PopupSummaryResponse;
-import com.example.demo.application.dto.popup.PopupCursorResponse;
 import com.example.demo.application.service.PopupService;
+import com.example.demo.common.security.UserPrincipal;
 import com.example.demo.presentation.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/popups")
@@ -36,9 +38,11 @@ public class PopupController {
     }
 
     @GetMapping("/{popupId}")
-    public ResponseEntity<ApiResponse<PopupDetailResponse>> getPopupDetail(@PathVariable Long popupId) {
-        // TODO 로그인한 유저의 정보를 넘길 예정
-        PopupDetailResponse popupDetail = popupService.getPopupDetail(popupId, 1000L);
+    public ResponseEntity<ApiResponse<PopupDetailResponse>> getPopupDetail(@PathVariable Long popupId,@AuthenticationPrincipal UserPrincipal principal) {
+        if (principal == null) {
+            throw new IllegalStateException("인증된 사용자 정보를 가져올 수 없습니다.");
+        }
+        PopupDetailResponse popupDetail = popupService.getPopupDetail(popupId, principal.getId());
         return ResponseEntity.ok(new ApiResponse<>("팝업 상세 조회가 성공했습니다.", popupDetail));
     }
 }

--- a/backend/src/main/java/com/example/demo/presentation/controller/WaitingController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/WaitingController.java
@@ -4,9 +4,11 @@ import com.example.demo.application.dto.waiting.VisitHistoryCursorResponse;
 import com.example.demo.application.dto.waiting.WaitingCreateRequest;
 import com.example.demo.application.dto.waiting.WaitingCreateResponse;
 import com.example.demo.application.service.WaitingService;
+import com.example.demo.common.security.UserPrincipal;
 import com.example.demo.presentation.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -43,9 +45,10 @@ public class WaitingController {
     public ResponseEntity<ApiResponse<VisitHistoryCursorResponse>> getVisitHistory(
             @RequestParam(defaultValue = "10") Integer size,
             @RequestParam(required = false) Long lastWaitingId,
-            @RequestParam(required = false) String status
+            @RequestParam(required = false) String status,
+            @AuthenticationPrincipal UserPrincipal principal
     ) {
-        VisitHistoryCursorResponse response = waitingService.getVisitHistory(size, lastWaitingId, status);
+        VisitHistoryCursorResponse response = waitingService.getVisitHistory(principal.getId(),size, lastWaitingId, status);
 
         return ResponseEntity.ok(new ApiResponse<>("성공적으로 조회되었습니다.", response));
     }

--- a/backend/src/main/java/com/example/demo/presentation/controller/handler/OAuth2FailureHandler.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/handler/OAuth2FailureHandler.java
@@ -1,0 +1,38 @@
+package com.example.demo.presentation.controller.handler;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler {
+
+    @Value("${custom.app.frontend-url}")
+    private String frontendUrl;
+
+    public void handleFailure(HttpServletResponse response, Exception e) throws IOException {
+        String reasonCode = resolveReasonCode(e);
+        redirectToFail(response, reasonCode);
+    }
+
+    private String resolveReasonCode(Exception e) {
+        if (e instanceof HttpClientErrorException || e instanceof IllegalStateException) {
+            return "token_exchange_failed";
+        }
+        return "server_error";
+    }
+
+    private void redirectToFail(HttpServletResponse response, String reasonCode) throws IOException {
+        String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl)
+            .path("/login/fail")
+            .queryParam("reason", reasonCode)
+            .build()
+            .toUriString();
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/backend/src/main/java/com/example/demo/presentation/controller/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,39 @@
+package com.example.demo.presentation.controller.handler;
+
+import com.example.demo.common.jwt.JwtProperties;
+import com.example.demo.common.jwt.JwtTokenProvider;
+import com.example.demo.common.security.UserPrincipal;
+import com.example.demo.common.util.CookieUtils;
+import com.example.demo.domain.model.Member;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+
+    public void onAuthenticationSuccess(HttpServletResponse response, Member member, String state, String frontendUrl) throws IOException {
+        UserPrincipal principal = UserPrincipal.create(member.id());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        
+        String accessToken = jwtTokenProvider.createToken(authentication);
+
+        response.addCookie(CookieUtils.createAccessTokenCookie(accessToken, jwtProperties.expirationSeconds()));
+
+        String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl)
+                .path(state)
+                .build()
+                .toUriString();
+
+        response.sendRedirect(redirectUrl);
+    }
+} 

--- a/backend/src/main/java/com/example/demo/presentation/controller/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/handler/OAuth2SuccessHandler.java
@@ -22,7 +22,7 @@ public class OAuth2SuccessHandler {
     private final JwtProperties jwtProperties;
 
     public void onAuthenticationSuccess(HttpServletResponse response, Member member, String state, String frontendUrl) throws IOException {
-        UserPrincipal principal = UserPrincipal.create(member.id());
+        UserPrincipal principal = UserPrincipal.create(member.id(), member.email());
         Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
         
         String accessToken = jwtTokenProvider.createToken(authentication);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdb
@@ -22,7 +24,33 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 1000
-
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${OAUTH2_KAKAO_CLIENT_ID}
+            client-secret: ${OAUTH2_KAKAO_CLIENT_SECRET}
+            redirect-uri: "${BACKEND_URL}/oauth/kakao/callback"
+            authorization_grant_type: authorization_code
+            client-authentication-method: client_secret_post
+            client_name: Kakao
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: ${OAUTH2_KAKAO_PROVIDER_AUTHORIZATION_URI}
+            token-uri: ${OAUTH2_KAKAO_PROVIDER_TOKEN_URI}
+            user-info-uri: ${OAUTH2_KAKAO_PROVIDER_USER_INFO_URI}
+            user-name-attribute: id
+custom:
+  app:
+    frontend-url: ${FRONTEND_URL}
+  jwt:
+    accessToken:
+      secret: ${JWT_ACCESS_TOKEN_SECRET}
+      expirationSeconds: ${JWT_ACCESS_TOKEN_EXPIRATION_SECONDS}
 logging:
   level:
     org.hibernate.SQL: DEBUG


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #96 

## 변경사항 설명
이 PR에서 어떤 변경사항이 있었는지 설명해주세요.

###  카카오 소셜 로그인 기능 구현
* REST API 방식의 Kakao OAuth2 인증 처리
* 인가 코드 → access token 발급 → 사용자 정보 조회
* 최초 로그인 시 `Member`, `OAuthAccount` 저장
* 이미 존재하는 OAuth 연결 시 기존 회원 로그인

### JWT 기반 인증 도입
* 로그인 시 JWT 발급 및 HttpOnly + Secure 쿠키 저장
* 커스텀 JwtAuthenticationFilter를 통해 인증 사용자 주입
* 사용자 식별을 위한 UserPrincipal 도입
* JWT에서 사용자 정보를 추출하여 SecurityContext에 Authentication 주입
* 인증된 사용자 정보를 /api/me로 조회 가능하도록 구현

### API 추가
* `GET /api/me` : 현재 로그인된 사용자 정보를 반환
* DTO: `MeResponse` 사용

✅ 환경 및 구성
* 도메인 구조에 맞춘 MemberPort, OAuthAccountPort 구현
* OAuthProvider 확장형 구조 적용
* RestTemplate Bean 등록 (RestTemplateConfig)
* application.yml에 Kakao OAuth2, JWT 설정 추가
* 민감 정보는 .env 파일로 분리하여 환경 변수 기반 설정

## 일정
- 리뷰 요청 기한: 2025-07-21
- 머지 예정일: 2025-07-21


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: OAuth 계정 도메인 분리 및 확장성 
- 성능 관련: 
- 보안 관련: 외부 노출 위험 요소(CSRF, access\_token 노출 등) 방지 처리
- 기타: 
  - JWT 발급 및 필터 적용 방식, 쿠키 설정(`HttpOnly`, `Secure`) 
  - /api/me 응답 구조 및 인증 사용자 바인딩 방식 (@AuthenticationPrincipal)
  - `application.yml`과 `.env` 간 의존성 구성 방식

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:

저는 임의로 프론트엔드에서 버튼을 만들어서 진행했습니다.
1. `.env` 파일에 카카오 OAuth 설정 및 JWT 비밀키 설정
2. 프론트에서 카카오 로그인 버튼 클릭
3. 카카오 로그인 후 쿠키에 `accessToken` 발급 여부 확인
4. 로그인 후 `/api/me` 요청 시 사용자 정보 정상 반환 확인
5. 쿠키 제거 또는 만료 후 접근 시 인증 오류 반환 확인
6. 이미 등록된 OAuth 연결로 로그인 시 기존 회원으로 정상 로그인 되는지 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?(최종 승인 후 반영 에정)
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.
- 프론트 임의로 버튼 구현 후 로그인 성공 토큰 저장 확인
<img width="1576" height="1494" alt="image" src="https://github.com/user-attachments/assets/1e1c9362-a0dc-486d-8e96-f8e6960e6f3e" />
- 발급받은 토큰을 이용해서 내 정보 조회
<img width="1060" height="624" alt="image" src="https://github.com/user-attachments/assets/3828ff17-763f-41ea-b93e-acac310d7e45" />

## 추가 정보
추가적인 정보나 컨텍스트가 있다면 여기에 작성해주세요. 
- env파일 공유 예정