### PR TITLE
(Feat/#129) 알림 읽기 / 삭제 API 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/application/dto/notification/NotificationDeleteRequest.java
+++ b/backend/src/main/java/com/example/demo/application/dto/notification/NotificationDeleteRequest.java
@@ -1,0 +1,6 @@
+package com.example.demo.application.dto.notification;
+
+public record NotificationDeleteRequest(
+        Long notificationId
+) {
+} 

--- a/backend/src/main/java/com/example/demo/application/dto/notification/NotificationReadRequest.java
+++ b/backend/src/main/java/com/example/demo/application/dto/notification/NotificationReadRequest.java
@@ -1,0 +1,6 @@
+package com.example.demo.application.dto.notification;
+
+public record NotificationReadRequest(
+        Long notificationId
+) {
+}

--- a/backend/src/main/java/com/example/demo/application/service/NotificationService.java
+++ b/backend/src/main/java/com/example/demo/application/service/NotificationService.java
@@ -2,6 +2,8 @@ package com.example.demo.application.service;
 
 import com.example.demo.application.dto.notification.NotificationListRequest;
 import com.example.demo.application.dto.notification.NotificationListResponse;
+import com.example.demo.application.dto.notification.NotificationReadRequest;
+import com.example.demo.application.dto.notification.NotificationResponse;
 import com.example.demo.application.mapper.NotificationDtoMapper;
 import com.example.demo.domain.model.CursorResult;
 import com.example.demo.domain.model.notification.Notification;
@@ -15,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class NotificationService {
 
     private final NotificationPort notificationPort;
@@ -27,11 +29,11 @@ public class NotificationService {
 
     public NotificationListResponse getNotifications(NotificationListRequest request) {
         int pageSize = validateAndSetPageSize(request.size());
-        
+
         ReadStatus status = parseReadStatus(request.readStatus());
-        
+
         NotificationSortOrder sortOrder = parseSortOrder(request.sort());
-        
+
         NotificationQuery query = NotificationQuery.builder()
                 .memberId(request.memberId())
                 .lastNotificationId(request.lastNotificationId())
@@ -39,9 +41,9 @@ public class NotificationService {
                 .pageSize(pageSize)
                 .sortOrder(sortOrder)
                 .build();
-        
+
         CursorResult<Notification> result = notificationPort.findAllBy(query);
-        
+
         return notificationDtoMapper.toCursorResponse(result);
     }
 
@@ -62,7 +64,7 @@ public class NotificationService {
         if (readStatusStr == null || "ALL".equalsIgnoreCase(readStatusStr)) {
             return null; // null이면 전체 조회
         }
-        
+
         try {
             return ReadStatus.valueOf(readStatusStr.toUpperCase());
         } catch (IllegalArgumentException e) {
@@ -74,11 +76,26 @@ public class NotificationService {
         if (sortStr == null) {
             return DEFAULT_SORT_ORDER;
         }
-        
+
         try {
             return NotificationSortOrder.valueOf(sortStr.toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("유효하지 않은 정렬 옵션입니다: " + sortStr);
         }
+    }
+
+    public NotificationResponse markNotificationAsRead(Long memberId, NotificationReadRequest request) {
+        Notification notification = notificationPort.findAllBy(NotificationQuery.findByNotificationId(request.notificationId()))
+                .content().stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 알림입니다: " + request.notificationId()));
+
+        if (!notification.getMember().id().equals(memberId)) {
+            throw new IllegalArgumentException("해당 알림은 다른 회원의 것입니다: " + request.notificationId());
+        }
+
+        notification.read();
+        notificationPort.save(notification);
+        return notificationDtoMapper.toNotificationResponse(notification);
     }
 } 

--- a/backend/src/main/java/com/example/demo/application/service/NotificationService.java
+++ b/backend/src/main/java/com/example/demo/application/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.example.demo.application.dto.notification.NotificationListRequest;
 import com.example.demo.application.dto.notification.NotificationListResponse;
 import com.example.demo.application.dto.notification.NotificationReadRequest;
 import com.example.demo.application.dto.notification.NotificationResponse;
+import com.example.demo.application.dto.notification.NotificationDeleteRequest;
 import com.example.demo.application.mapper.NotificationDtoMapper;
 import com.example.demo.domain.model.CursorResult;
 import com.example.demo.domain.model.notification.Notification;
@@ -97,5 +98,18 @@ public class NotificationService {
         notification.read();
         notificationPort.save(notification);
         return notificationDtoMapper.toNotificationResponse(notification);
+    }
+
+    public void deleteNotification(Long memberId, NotificationDeleteRequest request) {
+        Notification notification = notificationPort.findAllBy(NotificationQuery.findByNotificationId(request.notificationId()))
+                .content().stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 알림입니다: " + request.notificationId()));
+
+        if (!notification.getMember().id().equals(memberId)) {
+            throw new IllegalArgumentException("해당 알림은 다른 회원의 것입니다: " + request.notificationId());
+        }
+
+        notificationPort.delete(notification);
     }
 } 

--- a/backend/src/main/java/com/example/demo/common/util/CookieUtils.java
+++ b/backend/src/main/java/com/example/demo/common/util/CookieUtils.java
@@ -1,26 +1,35 @@
 package com.example.demo.common.util;
 
-import jakarta.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
 
 public class CookieUtils {
 
     public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
 
-    public static Cookie createAccessTokenCookie(String token, long maxAgeSeconds) {
-        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, token);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge((int) maxAgeSeconds);
-        return cookie;
+    /**
+     * 액세스 토큰 쿠키 생성
+     * SameSite=Lax; HttpOnly 설정으로 보안과 호환성을 모두 고려
+     */
+    public static ResponseCookie createAccessTokenCookie(String token, long maxAgeSeconds) {
+        return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, token)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .secure(true)
+                .sameSite("None")
+                .build();
     }
 
-    public static Cookie deleteAccessTokenCookie() {
-        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, null);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        return cookie;
+    /**
+     * 쿠키 삭제용
+     */
+    public static ResponseCookie deleteAccessTokenCookie() {
+        return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .secure(true)
+                .sameSite("None")
+                .build();
     }
 } 

--- a/backend/src/main/java/com/example/demo/config/AppProperties.java
+++ b/backend/src/main/java/com/example/demo/config/AppProperties.java
@@ -1,0 +1,12 @@
+package com.example.demo.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "custom.app")
+public class AppProperties {
+    private String frontendUrl;
+} 

--- a/backend/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -16,6 +16,11 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -27,10 +32,25 @@ public class SecurityConfig {
     // TODO: 아키텍처 리팩토링 https://github.com/JECT-Study/JECT-3th-6team/pull/99
 
     @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(Arrays.asList("*")); // 모든 origin 허용 (개발 환경용)
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Content-Type"));
+        
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
     @Profile("sse-test")
     public SecurityFilterChain sseTestSecurityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 //h2 확인을 위한 설정 TODO: MySQL 연결시 삭제
@@ -64,6 +84,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 //h2 확인을 위한 설정 TODO: MySQL 연결시 삭제

--- a/backend/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -21,24 +21,30 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, AppProperties.class})
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final AppProperties appProperties;
+    
     // TODO: 아키텍처 리팩토링 https://github.com/JECT-Study/JECT-3th-6team/pull/99
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("*")); // 모든 origin 허용 (개발 환경용)
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        
+        // application.yml에서 설정된 frontend-url 사용
+        configuration.setAllowedOrigins(Arrays.asList(appProperties.getFrontendUrl()));
+        
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setAllowCredentials(true);
-        configuration.setExposedHeaders(Arrays.asList("Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true); // 쿠키 인증을 위해 필수
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Content-Type", "Set-Cookie"));
         
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/backend/src/main/java/com/example/demo/domain/model/notification/NotificationQuery.java
+++ b/backend/src/main/java/com/example/demo/domain/model/notification/NotificationQuery.java
@@ -1,6 +1,5 @@
 package com.example.demo.domain.model.notification;
 
-import com.example.demo.domain.model.notification.ReadStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,5 +21,11 @@ public class NotificationQuery {
         this.readStatus = readStatus;
         this.pageSize = pageSize;
         this.sortOrder = sortOrder;
+    }
+
+    public static NotificationQuery findByNotificationId(Long notificationId) {
+        return NotificationQuery.builder()
+                .notificationId(notificationId)
+                .build();
     }
 } 

--- a/backend/src/main/java/com/example/demo/domain/port/NotificationPort.java
+++ b/backend/src/main/java/com/example/demo/domain/port/NotificationPort.java
@@ -8,5 +8,7 @@ public interface NotificationPort {
 
     Notification save(Notification notification);
 
+    Notification update(Notification notification);
+
     CursorResult<Notification> findAllBy(NotificationQuery query);
 } 

--- a/backend/src/main/java/com/example/demo/domain/port/NotificationPort.java
+++ b/backend/src/main/java/com/example/demo/domain/port/NotificationPort.java
@@ -8,7 +8,7 @@ public interface NotificationPort {
 
     Notification save(Notification notification);
 
-    Notification update(Notification notification);
-
     CursorResult<Notification> findAllBy(NotificationQuery query);
+
+    void delete(Notification notification);
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/NotificationPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/NotificationPortAdapter.java
@@ -17,10 +17,6 @@ import com.example.demo.infrastructure.persistence.mapper.NotificationEntityMapp
 import com.example.demo.infrastructure.persistence.repository.NotificationJpaRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.CriteriaUpdate;
-import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -49,27 +45,11 @@ public class NotificationPortAdapter implements NotificationPort {
     }
 
     @Override
-    public Notification update(Notification notification) {
+    public void delete(Notification notification) {
         if (notification.getId() == null) {
-            throw new IllegalArgumentException("알림 ID가 null입니다. 업데이트할 알림은 반드시 ID를 가져야 합니다.");
+            throw new IllegalArgumentException("알림 ID가 null입니다. 삭제할 알림은 반드시 ID를 가져야 합니다.");
         }
-        NotificationEntity entity = mapper.toEntity(notification);
-
-        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
-        CriteriaQuery<NotificationEntity> query = criteriaBuilder.createQuery(NotificationEntity.class);
-        Root<NotificationEntity> root = query.from(NotificationEntity.class);
-        CriteriaUpdate<NotificationEntity> update = criteriaBuilder.createCriteriaUpdate(NotificationEntity.class)
-                .set("memberId", entity.getMemberId())
-                .set("sourceDomain", entity.getSourceDomain())
-                .set("sourceId", entity.getSourceId())
-                .set("eventType", entity.getEventType())
-                .set("content", entity.getContent())
-                .set("status", entity.getStatus())
-                .set("readAt", entity.getReadAt())
-                .where(criteriaBuilder.equal(root.get("id"), notification.getId()));
-
-        em.createQuery(update).executeUpdate();
-        return notification;
+        repository.deleteById(notification.getId());
     }
 
     @Override

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/NotificationPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/NotificationPortAdapter.java
@@ -15,6 +15,12 @@ import com.example.demo.infrastructure.persistence.mapper.NotificationEntityMapp
 import com.example.demo.infrastructure.persistence.mapper.NotificationEntityMapper.DomainSpecificMapper;
 import com.example.demo.infrastructure.persistence.mapper.NotificationEntityMapper.SourceEntityKey;
 import com.example.demo.infrastructure.persistence.repository.NotificationJpaRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -29,6 +35,8 @@ public class NotificationPortAdapter implements NotificationPort {
     private final NotificationEntityMapper mapper;
     private final MemberPort memberPort;
     private final WaitingPort waitingPort;
+    @PersistenceContext
+    private final EntityManager em;
 
     // 도메인별 매퍼 (지연 초기화)
     private DomainSpecificMapper<Waiting> waitingMapper;
@@ -41,7 +49,38 @@ public class NotificationPortAdapter implements NotificationPort {
     }
 
     @Override
+    public Notification update(Notification notification) {
+        if (notification.getId() == null) {
+            throw new IllegalArgumentException("알림 ID가 null입니다. 업데이트할 알림은 반드시 ID를 가져야 합니다.");
+        }
+        NotificationEntity entity = mapper.toEntity(notification);
+
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+        CriteriaQuery<NotificationEntity> query = criteriaBuilder.createQuery(NotificationEntity.class);
+        Root<NotificationEntity> root = query.from(NotificationEntity.class);
+        CriteriaUpdate<NotificationEntity> update = criteriaBuilder.createCriteriaUpdate(NotificationEntity.class)
+                .set("memberId", entity.getMemberId())
+                .set("sourceDomain", entity.getSourceDomain())
+                .set("sourceId", entity.getSourceId())
+                .set("eventType", entity.getEventType())
+                .set("content", entity.getContent())
+                .set("status", entity.getStatus())
+                .set("readAt", entity.getReadAt())
+                .where(criteriaBuilder.equal(root.get("id"), notification.getId()));
+
+        em.createQuery(update).executeUpdate();
+        return notification;
+    }
+
+    @Override
     public CursorResult<Notification> findAllBy(NotificationQuery query) {
+        if (query.getNotificationId() != null) {
+            // 단일 알림 조회
+            Notification notification = repository.findById(query.getNotificationId())
+                    .map(this::entityToDomain)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 알림입니다: " + query.getNotificationId()));
+            return new CursorResult<>(List.of(notification), false);
+        }
         List<NotificationEntity> entities = executeQuery(query);
 
         boolean hasNext = false;

--- a/backend/src/main/java/com/example/demo/presentation/controller/MemberController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/MemberController.java
@@ -6,9 +6,9 @@ import com.example.demo.common.util.CookieUtils;
 import com.example.demo.domain.model.Member;
 import com.example.demo.domain.port.MemberPort;
 import com.example.demo.presentation.ApiResponse;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,15 +29,15 @@ public class MemberController {
             throw new IllegalStateException("인증된 사용자 정보를 가져올 수 없습니다.");
         }
         Member member = memberPort.findById(principal.getId())
-            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + principal.getId()));
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + principal.getId()));
         return new ApiResponse<>("사용자 정보 조회 성공", MeResponse.from(member));
     }
 
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
-        Cookie deleteCookie = CookieUtils.deleteAccessTokenCookie();
-        response.addCookie(deleteCookie);
-        
+        ResponseCookie responseCookie = CookieUtils.deleteAccessTokenCookie();
+        response.setHeader("Set-Cookie", responseCookie.toString());
+
         return ResponseEntity.ok(new ApiResponse<>("로그아웃이 완료되었습니다.", null));
     }
 } 

--- a/backend/src/main/java/com/example/demo/presentation/controller/NotificationController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/NotificationController.java
@@ -2,6 +2,8 @@ package com.example.demo.presentation.controller;
 
 import com.example.demo.application.dto.notification.NotificationListRequest;
 import com.example.demo.application.dto.notification.NotificationListResponse;
+import com.example.demo.application.dto.notification.NotificationReadRequest;
+import com.example.demo.application.dto.notification.NotificationResponse;
 import com.example.demo.application.service.NotificationService;
 import com.example.demo.application.service.NotificationSseService;
 import com.example.demo.common.security.UserPrincipal;
@@ -9,9 +11,7 @@ import com.example.demo.presentation.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
@@ -61,5 +61,15 @@ public class NotificationController {
     public ApiResponse<Boolean> getConnectionStatus(@AuthenticationPrincipal UserPrincipal principal) {
         boolean isConnected = notificationSseService.isConnected(principal.getId());
         return new ApiResponse<>("연결 상태 조회 성공", isConnected);
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ApiResponse<NotificationResponse> markNotificationAsRead(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long notificationId
+    ) {
+        NotificationResponse notificationResponse = notificationService.markNotificationAsRead(principal.getId(), new NotificationReadRequest(notificationId));
+
+        return new ApiResponse<>("알림 읽기 성공", notificationResponse);
     }
 }

--- a/backend/src/main/java/com/example/demo/presentation/controller/NotificationController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/NotificationController.java
@@ -4,6 +4,7 @@ import com.example.demo.application.dto.notification.NotificationListRequest;
 import com.example.demo.application.dto.notification.NotificationListResponse;
 import com.example.demo.application.dto.notification.NotificationReadRequest;
 import com.example.demo.application.dto.notification.NotificationResponse;
+import com.example.demo.application.dto.notification.NotificationDeleteRequest;
 import com.example.demo.application.service.NotificationService;
 import com.example.demo.application.service.NotificationSseService;
 import com.example.demo.common.security.UserPrincipal;
@@ -71,5 +72,15 @@ public class NotificationController {
         NotificationResponse notificationResponse = notificationService.markNotificationAsRead(principal.getId(), new NotificationReadRequest(notificationId));
 
         return new ApiResponse<>("알림 읽기 성공", notificationResponse);
+    }
+
+    @DeleteMapping("/{notificationId}")
+    public ApiResponse<Void> deleteNotification(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long notificationId
+    ) {
+        notificationService.deleteNotification(principal.getId(), new NotificationDeleteRequest(notificationId));
+
+        return new ApiResponse<>("알림 삭제 성공", null);
     }
 }

--- a/backend/src/main/java/com/example/demo/presentation/controller/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/handler/OAuth2SuccessHandler.java
@@ -7,6 +7,7 @@ import com.example.demo.common.util.CookieUtils;
 import com.example.demo.domain.model.Member;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -24,10 +25,11 @@ public class OAuth2SuccessHandler {
     public void onAuthenticationSuccess(HttpServletResponse response, Member member, String state, String frontendUrl) throws IOException {
         UserPrincipal principal = UserPrincipal.create(member.id(), member.email());
         Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
-        
+
         String accessToken = jwtTokenProvider.createToken(authentication);
 
-        response.addCookie(CookieUtils.createAccessTokenCookie(accessToken, jwtProperties.expirationSeconds()));
+        ResponseCookie responseCookie = CookieUtils.createAccessTokenCookie(accessToken, jwtProperties.expirationSeconds());
+        response.setHeader("Set-Cookie", responseCookie.toString());
 
         String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl)
                 .path(state)


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #129 

## 변경사항 설명

알림 읽기 및 삭제 기능 구현.

### 🔔 알림 읽기 기능
- **API**: `PATCH /api/notifications/{notificationId}/read`
- **기능**: 특정 알림을 읽음 상태로 변경하고 읽은 시간 기록
- **보안**: 본인 소유 알림만 읽기 가능

### 🗑️ 알림 삭제 기능  
- **API**: `DELETE /api/notifications/{notificationId}`
- **기능**: 특정 알림을 완전히 삭제
- **보안**: 본인 소유 알림만 삭제 가능

### 📋 구현 내용
- `NotificationReadRequest`, `NotificationDeleteRequest` DTO 추가
- `NotificationService`에 `markNotificationAsRead()`, `deleteNotification()` 메서드 추가
- `NotificationPort`에 `delete()` 메서드 추가
- `NotificationPortAdapter`에 `delete()` 구현
- `NotificationController`에 읽기/삭제 엔드포인트 추가
- API 문서 업데이트

### 쿠키 인증 보완

- 브라우저에서 쿠키로 인증을 하기 위해서는 SameSite 쿠키 설정을 부여해야 하고, 허용된 출처 목록 (`*`불허) 만 지정해야 하기 때문에 설정 추가했습니다.
- [참고 자료](https://velog.io/@teamdevelup/%EC%8B%9C%EC%97%B0-2%EC%8B%9C%EA%B0%84-%EB%82%A8%EC%95%98%EB%8A%94%EB%8D%B0-%ED%95%98%EC%96%80-%ED%99%94%EB%A9%B4%EC%9D%B4-%EB%9C%AC%EB%8B%A4%EA%B3%A0#%ED%95%B4%EA%B2%B0%EC%B1%85---%EC%9D%B4%EB%A1%A0)

## 일정
- 리뷰 요청 기한: 2025-07-30
- 머지 예정일: 2025-07-31

## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 기존 알림 조회 기능과 동일한 패턴으로 구현했는지, 클린 아키텍처 원칙을 잘 따랐는지
- 성능 관련: 
- 보안 관련: 

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [x] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.

## 추가 정보

### 🧪 테스트 데이터
`data.sql`에 있는 기존 알림 데이터로 테스트 가능합니다:
- 알림 ID: 500, 501, 502, 504, 505, 507, 508
- 회원 ID: 1000, 1001

### 📝 API 사용 예시
```bash
# 알림 읽기
PATCH /api/notifications/500/read
Authorization: Bearer <jwt_token>

# 알림 삭제  
DELETE /api/notifications/500
Authorization: Bearer <jwt_token>
```

### ⚠️ 주의사항
- 삭제된 알림은 복구할 수 없습니다
- 본인의 알림만 읽기/삭제 가능합니다
- JWT 인증이 필수입니다