### PR TITLE
(Feat/#139/fe) SSE 알림 수신 및 홈화면 알림 모달창

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node server.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,0 +1,22 @@
+import { createServer } from 'https';
+import { parse } from 'url';
+import { readFileSync } from 'fs';
+import next from 'next';
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+const httpsOptions = {
+  key: readFileSync('./localhost+2-key.pem'),
+  cert: readFileSync('./localhost+2.pem'),
+};
+
+app.prepare().then(() => {
+  createServer(httpsOptions, async (req, res) => {
+    const parsedUrl = parse(req.url, true);
+    await handle(req, res, parsedUrl);
+  }).listen(3000, () => {
+    console.log('🚀 Ready on https://localhost:3000');
+  });
+});

--- a/frontend/src/app/(with-navbar)/(home)/page.tsx
+++ b/frontend/src/app/(with-navbar)/(home)/page.tsx
@@ -5,10 +5,12 @@ import FilterKeywordSelect from '@/features/filtering/ui/FilterKeywordSelect';
 import FilteredPopupList from '@/features/filtering/ui/FilteredPopupList';
 import { Suspense } from 'react';
 import PopupCardListSuspenseFallback from '@/entities/popup/ui/PopupCardListSuspenseFallback';
+import NotificationModal from '@/features/notification/ui/NotificationModal';
 
 export default function Home() {
   return (
     <FilterProvider>
+      <NotificationModal />
       <FilterSelectButtonGroup />
       <FilterKeywordSelect />
       <FilterBottomSheet />

--- a/frontend/src/features/notification/api/getNotificationsApi.ts
+++ b/frontend/src/features/notification/api/getNotificationsApi.ts
@@ -1,0 +1,36 @@
+import { APIBuilder, logError } from '@/shared/lib';
+import NotificationType from '@/features/notification/type/Notification';
+import { ApiError } from '@/shared/type/api';
+
+type NotificationRequest = {
+  size: number;
+  lastNotificationId: number;
+  readStatus: 'READ' | 'UNREAD' | 'ALL';
+  sort: 'UNREAD_FIRST' | 'TIME_DESC';
+};
+
+type NotificationResponse = {
+  contents: NotificationType[];
+  lastNotificationId: number;
+  hasNext: boolean;
+};
+
+export default async function getNotificationsApi(
+  request: NotificationRequest
+) {
+  try {
+    const builder = await APIBuilder.get('/notifications')
+      .params(request)
+      .timeout(5000)
+      .withCredentials(true)
+      .auth()
+      .buildAsync();
+    const response = await builder.call<NotificationResponse>();
+    return response.data;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      logError(error, '알림 목록 조회 과정');
+    }
+    throw error;
+  }
+}

--- a/frontend/src/features/notification/hook/useNotificationListener.ts
+++ b/frontend/src/features/notification/hook/useNotificationListener.ts
@@ -1,0 +1,61 @@
+import { useNotificationStore } from '@/features/notification/hook/useNotificationStore';
+import { useEffect, useRef } from 'react';
+
+/**
+ * 홈 페이지 진입시 단한번 백엔드로 연결 요청 (new EventSource('/api/notifications/stream))
+ * 하트비트 이벤트 : event.type === 'ping' -> 연결 유지용
+ * 실제 알림 이벤트 : event.type === 'notification' -> 전역 상태 업데이트 -> UI 업데이트
+ */
+
+export default function useNotificationListener() {
+  const addNotification = useNotificationStore(state => state.add);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (eventSourceRef.current) return;
+
+    const eventSource = new EventSource(
+      `${process.env.NEXT_PUBLIC_API_URL}/notifications/stream`,
+      { withCredentials: true }
+    );
+    eventSourceRef.current = eventSource;
+
+    // 테스트용
+    eventSource.onopen = () => {
+      console.log('✅ SSE 연결 성공');
+    };
+
+    eventSource.addEventListener('ping', event =>
+      console.log('💗 PING', event.data)
+    );
+
+    eventSource.addEventListener('notification', event => {
+      try {
+        const notification = JSON.parse(event.data);
+        addNotification(notification);
+      } catch (error) {
+        console.warn('알림 메세지 데이터 파싱실패', error);
+      }
+    });
+
+    eventSource.onerror = error => {
+      if (eventSource.readyState === EventSource.CLOSED) {
+        console.log('SSE 연결 정상 종료(페이지 이탈/새로고침)');
+      } else {
+        console.error('SSE 오류', error);
+      }
+    };
+
+    // 새로고침시 정상 종료
+    const handleUnload = () => eventSource.close();
+    window.addEventListener('beforeunload', handleUnload);
+
+    // 페이지 언마운트 시 연결 해제
+    return () => {
+      window.removeEventListener('beforeunload', handleUnload);
+      eventSource.close();
+      eventSourceRef.current = null;
+      console.log('연결 해제');
+    };
+  }, []);
+}

--- a/frontend/src/features/notification/hook/useNotificationStore.ts
+++ b/frontend/src/features/notification/hook/useNotificationStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import NotificationType from '@/features/notification/type/Notification';
+import dummyNotificationList from '@/features/notification/api/DummyNotification';
 
 interface NotificationState {
   list: NotificationType[];
@@ -8,7 +9,7 @@ interface NotificationState {
 }
 
 export const useNotificationStore = create<NotificationState>(set => ({
-  list: [],
+  list: [...dummyNotificationList],
   add: noti => set(({ list }) => ({ list: [...list, noti] })),
   remove: (id: number) =>
     set(state => ({

--- a/frontend/src/features/notification/hook/useNotificationStore.ts
+++ b/frontend/src/features/notification/hook/useNotificationStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import NotificationType from '@/features/notification/type/Notification';
+
+interface NotificationState {
+  list: NotificationType[];
+  add: (noti: NotificationType) => void;
+  remove: (id: number) => void;
+}
+
+export const useNotificationStore = create<NotificationState>(set => ({
+  list: [],
+  add: noti => set(({ list }) => ({ list: [...list, noti] })),
+  remove: (id: number) =>
+    set(state => ({
+      list: state.list.filter(noti => noti.notificationId !== id),
+    })),
+}));

--- a/frontend/src/features/notification/ui/NotificationBell.tsx
+++ b/frontend/src/features/notification/ui/NotificationBell.tsx
@@ -1,9 +1,11 @@
+'use client';
 import BellIcon from '@/assets/icons/Normal/Icon_Bell.svg';
 import Link from 'next/link';
+import useNotificationListener from '@/features/notification/hook/useNotificationListener';
 
 export default function NotificationBell() {
   // TODO 알림여부에 따라 링 보여지는 여부가 달라짐
-
+  useNotificationListener();
   return (
     <div className={'relative'}>
       <Link href={'/notify'} className={'absolute top-0 right-0 z-3'}>

--- a/frontend/src/features/notification/ui/NotificationCard.tsx
+++ b/frontend/src/features/notification/ui/NotificationCard.tsx
@@ -24,7 +24,7 @@ export default function NotificationCard({
   const { notificationTitle, message, isRead, createdAt } = data;
 
   const style = tv({
-    base: 'relative rounded-[10px] flex flex-col gap-y-[10px] p-[16px] hover:bg-sub2/20',
+    base: 'relative rounded-[10px] flex flex-col gap-y-[10px] p-[16px] hover:bg-sub2 bg-white',
     variants: {
       isRead: {
         true: 'border border-gray40',

--- a/frontend/src/features/notification/ui/NotificationModal.tsx
+++ b/frontend/src/features/notification/ui/NotificationModal.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useNotificationStore } from '@/features/notification/hook/useNotificationStore';
+import { ModalContainer } from '@/shared/ui';
+import NotificationCard from './NotificationCard';
+import useNotificationNavigation from '@/features/notification/hook/useNotificationNavigation';
+import { useEffect, useState } from 'react';
+
+export default function NotificationModal() {
+  const [isOpen, setOpen] = useState<boolean>(false);
+  const notiList = useNotificationStore(state => state.list);
+  const remove = useNotificationStore(state => state.remove);
+  const handleCardClick = useNotificationNavigation();
+
+  useEffect(() => {
+    if (notiList.length > 0) {
+      setOpen(true);
+    } else {
+      setOpen(false);
+    }
+  }, [notiList]);
+
+  return (
+    <ModalContainer open={isOpen} className={'items-start'}>
+      <div
+        className={
+          'flex flex-col gap-y-2 px-5 pt-4.5 min-w-[320px] max-w-[430px] mx-auto '
+        }
+      >
+        {notiList.map(noti => (
+          <NotificationCard
+            key={noti.notificationId}
+            data={noti}
+            onClose={() => remove(noti.notificationId)}
+            onClick={() =>
+              handleCardClick(noti.notificationCode, noti.relatedResource.id)
+            }
+          />
+        ))}
+      </div>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/shared/ui/modal/ModalContainer.tsx
+++ b/frontend/src/shared/ui/modal/ModalContainer.tsx
@@ -1,12 +1,18 @@
 'use client';
 import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
+import { cn } from '@/lib/utils';
 
 interface ModalProps extends React.PropsWithChildren {
   open: boolean;
+  className?: string;
 }
 
-export default function ModalContainer({ open, children }: ModalProps) {
+export default function ModalContainer({
+  open,
+  className,
+  children,
+}: ModalProps) {
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
@@ -19,7 +25,12 @@ export default function ModalContainer({ open, children }: ModalProps) {
     <>
       {open ? (
         // 모달 컨테이너
-        <div className="fixed top-0 left-0 w-full h-full flex justify-center items-center bg-modal-overlay z-100 backdrop-blur-[2px]">
+        <div
+          className={cn(
+            'fixed top-0 left-0 w-full h-full flex justify-center items-center bg-modal-overlay z-100 backdrop-blur-[2px]',
+            className
+          )}
+        >
           {/* 모달 내용 */}
           <div>{children}</div>
         </div>


### PR DESCRIPTION
## 관련 이슈
close #139 

## 변경사항 설명
1. 알림 상태 관리 및 API 연동
- useNotificationStore 전역 상태 저장소 생성
- 알림 리스트 상태 관리 (list, add, remove)
- 전체 알림 조회 API 호출 함수 추가
 
2. 실시간 알림 수신 (SSE)
- useNotificationListener 훅 구현
  - 홈 페이지 진입 시 단 한 번만 SSE 연결
  - ping 이벤트 → 연결 유지용 (console 로그)
  - notification 이벤트 → 전역 상태에 알림 추가
- EventSource 정상 종료 처리
  - 페이지 언마운트 및 새로고침 시 연결 해제
  - 정상 종료와 에러 로그 구분
3. 알림 카드(NotificationCard) 및 알림 모달 컴포넌트 추가
 - 홈 화면에 알림 모달 연동 완료

4. 개발 환경 개선
 - Next.js 개발 서버를 HTTPS 환경으로 세팅
 - 로컬 환경에서 SSE 및 HttpOnly 쿠키 기반 인증 정상 동작 확인 

## 일정
- 리뷰 요청 기한: 2025-08-05
- 머지 예정일: 2025-08-05


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: 
 - useNotificationListener 훅의 SSE 연결/해제 패턴이 안전한지
 - 모달/알림 카드 UI 구조가 재사용성과 역할 분리 측면에서 적절한지

## 테스트 방법
-  페이지 이동 / 새로고침 시 SSE 정상 종료 확인
-  모달 x 버튼 클릭시 ui가 잘 업데이트 되는지 확인ㄴ

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [x] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.

## 추가 정보
 - 현재는 더미 알림으로 모달 UI 랜더링 확인, 이후 삭제 예정