### PR TITLE
Feat/#143 회원 탈퇴 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/application/service/MemberService.java
+++ b/backend/src/main/java/com/example/demo/application/service/MemberService.java
@@ -1,0 +1,39 @@
+package com.example.demo.application.service;
+
+import com.example.demo.application.dto.member.MeResponse;
+import com.example.demo.common.exception.BusinessException;
+import com.example.demo.common.exception.ErrorType;
+import com.example.demo.domain.model.Member;
+import com.example.demo.domain.port.MemberPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberPort memberPort;
+
+    /**
+     * 로그인된 회원 정보 조회
+     */
+    public MeResponse getMe(Long memberId) {
+        Member member = memberPort.findById(memberId)
+            .orElseThrow(() -> new BusinessException(ErrorType.MEMBER_NOT_FOUND, String.valueOf(memberId)));
+        return MeResponse.from(member);
+    }
+
+    /**
+     * 회원 탈퇴 (물리적 삭제)
+     */
+    @Transactional
+    public void deleteMember(Long memberId) {
+        // 존재 여부 확인 후 삭제
+        if (!memberPort.findById(memberId).isPresent()) {
+            throw new BusinessException(ErrorType.MEMBER_NOT_FOUND, String.valueOf(memberId));
+        }
+        memberPort.deleteById(memberId);
+    }
+}

--- a/backend/src/main/java/com/example/demo/domain/port/MemberPort.java
+++ b/backend/src/main/java/com/example/demo/domain/port/MemberPort.java
@@ -25,4 +25,11 @@ public interface MemberPort {
      * @return 저장된 회원 정보
      */
     Member save(Member member);
+
+    /**
+     * 회원 정보를 삭제한다.
+     *
+     * @param id 회원 ID
+     */
+    void deleteById(Long id);
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/MemberPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/MemberPortAdapter.java
@@ -31,4 +31,9 @@ public class MemberPortAdapter implements MemberPort {
         var savedEntity = memberJpaRepository.save(entity);
         return memberEntityMapper.toDomain(savedEntity);
     }
+
+    @Override
+    public void deleteById(Long id) {
+        memberJpaRepository.deleteById(id);
+    }
 } 

--- a/backend/src/main/java/com/example/demo/presentation/controller/MemberController.java
+++ b/backend/src/main/java/com/example/demo/presentation/controller/MemberController.java
@@ -5,14 +5,14 @@ import com.example.demo.common.exception.BusinessException;
 import com.example.demo.common.exception.ErrorType;
 import com.example.demo.common.security.UserPrincipal;
 import com.example.demo.common.util.CookieUtils;
-import com.example.demo.domain.model.Member;
-import com.example.demo.domain.port.MemberPort;
+import com.example.demo.application.service.MemberService;
 import com.example.demo.presentation.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,16 +23,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberPort memberPort;
+    private final MemberService memberService;
 
     @GetMapping("/me")
     public ApiResponse<MeResponse> getMe(@AuthenticationPrincipal UserPrincipal principal) {
         if (principal == null) {
             throw new BusinessException(ErrorType.AUTHENTICATION_REQUIRED);
         }
-        Member member = memberPort.findById(principal.getId())
-                .orElseThrow(() -> new BusinessException(ErrorType.MEMBER_NOT_FOUND, String.valueOf(principal.getId())));
-        return new ApiResponse<>("사용자 정보 조회 성공", MeResponse.from(member));
+        MeResponse response = memberService.getMe(principal.getId());
+        return new ApiResponse<>("사용자 정보 조회 성공", response);
     }
 
     @PostMapping("/logout")
@@ -41,5 +40,17 @@ public class MemberController {
         response.setHeader("Set-Cookie", responseCookie.toString());
 
         return ResponseEntity.ok(new ApiResponse<>("로그아웃이 완료되었습니다.", null));
+    }
+
+    /**
+     * 회원 탈퇴 (물리적 삭제)
+     */
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteMe(@AuthenticationPrincipal UserPrincipal principal) {
+        if (principal == null) {
+            throw new BusinessException(ErrorType.AUTHENTICATION_REQUIRED);
+        }
+        memberService.deleteMember(principal.getId());
+        return ResponseEntity.ok(new ApiResponse<>("회원 탈퇴가 완료되었습니다.", null));
     }
 } 


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #143 

## 변경사항 설명
이 PR에서 어떤 변경사항이 있었는지 설명해주세요.
- 회원 탈퇴 구현 (물리적 삭제)

## 일정
- 리뷰 요청 기한: 2025-08-07
- 머지 예정일: 2025-08-07


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: member 테이블을 참조하는 다른 테이블(Waiting, Notification, OAuthAccount 등)에 FK 제약이 없는 상태라 이번 PR에서는 회원 레코드만 물리적으로 삭제했습니다. 
연관 데이터(웨이팅·알림·OAuth 계정 등)를 ① 그대로 보존할지, ② 개인정보 마스킹 후 보존할지, ③ 함께 삭제할지에 대한 정책 결정이 필요합니다.

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. '...' 페이지로 이동
2. '....' 버튼 클릭
3. '....' 결과 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [x] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.

## 추가 정보
추가적인 정보나 컨텍스트가 있다면 여기에 작성해주세요. 