### PR TITLE
Feat/#146 현장 대기 자동 입장 기능 구현

### DIFF
--- a/backend/docs/todo/record-field-extension-guidelines.md
+++ b/backend/docs/todo/record-field-extension-guidelines.md
@@ -1,0 +1,217 @@
+# Record 필드 확장 가이드라인
+
+## 문제 상황
+
+WaitingQuery record에 새로운 필드를 추가하는 과정에서 다음과 같은 문제들이 발생했습니다:
+
+1. **하위 호환성 문제**: 새 필드 추가로 기존 생성자 호출부가 모두 컴파일 에러 발생
+2. **테스트 코드 영향**: 테스트에서 사용하던 생성자들이 모두 깨짐
+3. **코드 변경 범위**: 여러 파일에 걸쳐 수정 작업 필요
+4. **유지보수 부담**: 매번 필드 추가 시 반복되는 대규모 수정 작업
+
+## 필요한 규칙과 가이드라인
+
+### 1. Record 설계 원칙
+
+#### 1.1 초기 설계 시 확장성 고려
+```java
+// ❌ 나쁜 예: 확장성을 고려하지 않은 설계
+public record UserQuery(Long userId, String name) {}
+
+// ✅ 좋은 예: 확장 가능성을 고려한 설계
+public record UserQuery(
+    Long userId,        // 필수 식별자
+    String name,        // 기본 검색 조건
+    // 향후 확장 예정 필드들을 미리 고려
+    String email,       // 추가 검색 조건
+    Integer limit,      // 페이징
+    String sortBy       // 정렬 (맨 마지막에 배치)
+) {
+    // 기본값 제공하는 정적 팩토리 메서드
+    public static UserQuery simple(Long userId) {
+        return new UserQuery(userId, null, null, null, null);
+    }
+}
+```
+
+#### 1.2 Record vs Builder 패턴 선택 기준
+- **Record 사용**: 필드가 5개 이하, 불변 객체, 단순 데이터 전달
+- **Builder 패턴 사용**: 필드가 많거나 복잡한 초기화 로직, 선택적 필드 많음
+
+### 2. 필드 확장 규칙
+
+#### 2.1 필드 추가 위치 규칙
+```java
+public record WaitingQuery(
+    // 핵심 식별자 (변경되지 않음)
+    Long waitingId,
+    Long memberId,
+    
+    // 기본 조건들 (안정적)
+    Integer size,
+    Long lastWaitingId,
+    WaitingStatus status,
+    SortOrder sortOrder,
+    
+    // 새로운 필드는 항상 맨 마지막에 추가
+    Long popupId  // ← 새 필드
+) {
+```
+
+**규칙**: 새 필드는 **반드시 맨 마지막에 추가**하여 기존 순서를 유지
+
+#### 2.2 하위 호환성 유지 방법
+```java
+public record WaitingQuery(
+    Long waitingId, Long memberId, Integer size, 
+    Long lastWaitingId, WaitingStatus status, 
+    SortOrder sortOrder, Long popupId
+) {
+    
+    // 기존 필드만으로 구성된 생성자 제공
+    public WaitingQuery(Long waitingId, Long memberId, Integer size, 
+                       Long lastWaitingId, WaitingStatus status, 
+                       SortOrder sortOrder) {
+        this(waitingId, memberId, size, lastWaitingId, 
+             status, sortOrder, null); // 새 필드는 기본값
+    }
+    
+    // 점진적 마이그레이션을 위한 @Deprecated 활용
+    @Deprecated(since = "1.2", forRemoval = true)
+    public WaitingQuery(Long waitingId, Long memberId) {
+        this(waitingId, memberId, null, null, null, null, null);
+    }
+}
+```
+
+### 3. 정적 팩토리 메서드 활용
+
+#### 3.1 의미 있는 메서드명 규칙
+```java
+public record WaitingQuery(...) {
+    
+    // ✅ 용도가 명확한 팩토리 메서드
+    public static WaitingQuery forWaitingId(Long waitingId) { ... }
+    public static WaitingQuery forMemberHistory(Long memberId, Integer size) { ... }
+    public static WaitingQuery forPopupWaitings(Long popupId, WaitingStatus status) { ... }
+    
+    // ❌ 의미가 모호한 메서드명
+    public static WaitingQuery create(Long id) { ... }
+    public static WaitingQuery of(Long a, Long b) { ... }
+}
+```
+
+#### 3.2 기본값 제공 전략
+```java
+public static WaitingQuery firstPage(Long memberId, Integer size) {
+    return new WaitingQuery(
+        null,                                    // waitingId
+        memberId,                               // memberId  
+        size,                                   // size
+        null,                                   // lastWaitingId
+        null,                                   // status (전체 조회)
+        SortOrder.RESERVED_FIRST_THEN_DATE_DESC, // 기본 정렬
+        null                                    // popupId
+    );
+}
+```
+
+### 4. 변경 영향도 관리
+
+#### 4.1 변경 전 체크리스트
+- [ ] 기존 생성자 호출부 파악 (IDE 검색 활용)
+- [ ] 테스트 코드 영향도 분석
+- [ ] 하위 호환 생성자 추가 계획
+- [ ] 마이그레이션 순서 결정
+
+#### 4.2 단계별 마이그레이션 전략
+```java
+// Phase 1: 새 필드 추가 + 하위 호환 생성자
+public record WaitingQuery(..., Long popupId) {
+    public WaitingQuery(기존_필드들) { 
+        this(기존_필드들, null); 
+    }
+}
+
+// Phase 2: 새로운 사용처에서 새 필드 활용
+WaitingQuery query = WaitingQuery.forPopup(popupId, status);
+
+// Phase 3: 기존 코드 점진적 마이그레이션
+// 기존: new WaitingQuery(id, null, null, null, null, null)
+// 신규: WaitingQuery.forWaitingId(id)
+
+// Phase 4: 구 생성자 @Deprecated 처리 및 제거
+```
+
+### 5. 테스트 코드 관리
+
+#### 5.1 테스트 코드 영향 최소화
+```java
+// ❌ 직접 생성자 사용 (변경에 취약)
+@Test
+void test() {
+    WaitingQuery query = new WaitingQuery(1L, null, null, null, null, null);
+    // ...
+}
+
+// ✅ 정적 팩토리 메서드 사용 (변경에 안정적)
+@Test
+void test() {
+    WaitingQuery query = WaitingQuery.forWaitingId(1L);
+    // ...
+}
+```
+
+#### 5.2 테스트 유틸리티 클래스 활용
+```java
+public class WaitingQueryTestFixture {
+    public static WaitingQuery basicQuery() {
+        return WaitingQuery.forWaitingId(1L);
+    }
+    
+    public static WaitingQuery memberHistoryQuery(Long memberId) {
+        return WaitingQuery.forMemberHistory(memberId, 10);
+    }
+}
+```
+
+### 6. 문서화 및 커뮤니케이션
+
+#### 6.1 변경 사항 문서화
+- **CHANGELOG**: 필드 추가, 새로운 팩토리 메서드, Deprecated 사항
+- **Migration Guide**: 기존 코드 변경 방법, 권장 사항
+- **API 문서**: 새 필드의 용도, 기본값, 사용 예시
+
+#### 6.2 팀 내 커뮤니케이션
+- 변경 전 리뷰 요청
+- 영향받는 팀원들에게 사전 공지
+- 마이그레이션 계획 공유
+
+### 7. 도구 및 자동화
+
+#### 7.1 IDE 활용
+- Find Usages로 영향도 파악
+- Refactor 도구로 일괄 변경
+- 컴파일 에러를 통한 누락 방지
+
+#### 7.2 정적 분석 도구
+- 사용되지 않는 생성자 탐지
+- Deprecated 사용 현황 모니터링
+
+## 결론
+
+Record 필드 확장은 단순해 보이지만 실제로는 많은 영향을 미치는 작업입니다. 이 가이드라인을 따라:
+
+1. **설계 시점**에서 확장성을 고려하고
+2. **변경 시점**에서 하위 호환성을 유지하며  
+3. **사용 시점**에서 정적 팩토리 메서드를 활용하여
+
+안정적이고 유지보수가 용이한 코드를 작성할 수 있습니다.
+
+---
+
+**다음 액션 아이템**:
+- [ ] 기존 Record 클래스들의 확장성 검토
+- [ ] 정적 팩토리 메서드 패턴 적용
+- [ ] 테스트 코드의 직접 생성자 사용 현황 파악
+- [ ] 팀 내 Record 사용 가이드라인 수립

--- a/backend/docs/waiting-enter-concurrency-analysis.md
+++ b/backend/docs/waiting-enter-concurrency-analysis.md
@@ -1,0 +1,215 @@
+# 대기열 입장 처리 동시성 분석 및 해결방안
+
+## 문제 정의
+
+### 비즈니스 요구사항
+- 어떤 대기자가 입장 처리될 때, 같은 팝업의 나머지 대기자들의 대기 번호를 앞당겨야 함
+- 예: 대기번호 1,2,3,4,5에서 3번이 입장하면 → 1,2,4,5가 1,2,3,4로 변경
+
+### 동시성 문제점
+1. **Race Condition**: 여러 입장 처리가 동시에 발생할 때 순번 재배치 충돌
+2. **Lost Update**: 순번 변경 중 다른 트랜잭션의 변경사항 손실
+3. **Phantom Read**: 대기열 조회와 업데이트 사이에 새로운 대기 추가/삭제
+4. **Inconsistent State**: 부분적으로만 업데이트되어 순번이 중복되거나 누락
+
+## 해결방안 분석
+
+### 1. 비관적 락 (Pessimistic Locking)
+```sql
+-- 팝업의 모든 대기를 락으로 보호
+SELECT * FROM waiting 
+WHERE popup_id = ? AND status = 'WAITING' 
+ORDER BY waiting_number 
+FOR UPDATE;
+```
+
+**장점:**
+- 확실한 데이터 일관성 보장
+- 구현이 상대적으로 단순
+
+**단점:**
+- 성능 저하 (락 대기시간)
+- 데드락 가능성
+- 동시성 처리량 제한
+
+### 2. 낙관적 락 (Optimistic Locking)
+```java
+@Version
+private Long version;
+
+// 업데이트 시 버전 체크
+UPDATE waiting SET waiting_number = ?, version = version + 1
+WHERE id = ? AND version = ?;
+```
+
+**장점:**
+- 높은 동시성 처리량
+- 데드락 없음
+
+**단점:**
+- 충돌 시 재시도 로직 복잡
+- 대량 업데이트 시 충돌 확률 높음
+
+### 3. 분산 락 (Distributed Lock)
+```java
+@RedisLock(key = "popup:#{popupId}:enter")
+public void makeVisit(WaitingMakeVisitRequest request) {
+    // 입장 처리 로직
+}
+```
+
+**장점:**
+- 멀티 인스턴스 환경에서 안전
+- 애플리케이션 레벨에서 제어 가능
+
+**단점:**
+- Redis 등 외부 저장소 의존
+- 락 해제 실패 시 교착상태 위험
+
+### 4. 순번 재배치 방식 개선
+
+#### 4-1. 즉시 재배치 vs 배치 처리
+**즉시 재배치:**
+```java
+@Transactional
+public void makeVisit(WaitingMakeVisitRequest request) {
+    Waiting target = findWaiting(request.waitingId());
+    target.enter();
+    save(target);
+    
+    // 순번 앞당기기
+    reorderWaitingNumbers(target.popup().id(), target.waitingNumber());
+}
+```
+
+**배치 처리:**
+```java
+@Scheduled(fixedDelay = 30000) // 30초마다
+public void reorderAllPopupWaitings() {
+    List<Long> popupIds = getPopupsWithGaps();
+    popupIds.forEach(this::reorderPopupWaitings);
+}
+```
+
+#### 4-2. 벌크 업데이트 최적화
+```sql
+-- 한 번의 쿼리로 모든 순번 앞당기기
+UPDATE waiting 
+SET waiting_number = waiting_number - 1 
+WHERE popup_id = ? 
+  AND status = 'WAITING' 
+  AND waiting_number > ?;
+```
+
+### 5. 이벤트 기반 아키텍처
+```java
+@EventListener
+public void handleWaitingEntered(WaitingEnteredEvent event) {
+    // 비동기로 순번 재배치 처리
+    asyncReorderService.reorderWaitingNumbers(event.getPopupId(), event.getWaitingNumber());
+}
+```
+
+## 권장 해결방안
+
+### 1단계: 비관적 락 + 벌크 업데이트
+```java
+@Transactional
+public void makeVisit(WaitingMakeVisitRequest request) {
+    // 1. 팝업 단위로 락 획득
+    Waiting target = waitingPort.findByIdWithLock(request.waitingId());
+    
+    // 2. 입장 처리
+    Waiting entered = target.enter();
+    waitingPort.save(entered);
+    
+    // 3. 벌크 업데이트로 순번 앞당기기
+    waitingPort.decrementWaitingNumbers(
+        target.popup().id(), 
+        target.waitingNumber()
+    );
+}
+```
+
+### 2단계: 성능 최적화 (필요시)
+```java
+// Redis를 이용한 분산 락
+@RedisLock(key = "popup:#{#request.popupId}:reorder", timeout = 5000)
+@Transactional
+public void makeVisit(WaitingMakeVisitRequest request) {
+    // 입장 처리 로직
+}
+```
+
+### 3단계: 이벤트 기반 최적화 (고도화)
+```java
+@Transactional
+public void makeVisit(WaitingMakeVisitRequest request) {
+    Waiting target = findWaiting(request.waitingId());
+    Waiting entered = target.enter();
+    waitingPort.save(entered);
+    
+    // 이벤트 발행 - 비동기 순번 재배치
+    eventPublisher.publishEvent(new WaitingEnteredEvent(
+        entered.popup().id(), 
+        entered.waitingNumber()
+    ));
+}
+```
+
+## 구현 우선순위
+
+### Phase 1: 최소 기능 (MVP)
+- 비관적 락 + 동기 벌크 업데이트
+- 단일 인스턴스 환경에서 안전성 확보
+
+### Phase 2: 성능 개선
+- Redis 분산 락 도입
+- 멀티 인스턴스 환경 대응
+
+### Phase 3: 고도화
+- 이벤트 기반 비동기 처리
+- 배치 처리로 성능 최적화
+- 모니터링 및 알림 시스템
+
+## 테스트 시나리오
+
+### 동시성 테스트
+```java
+@Test
+void concurrentEnterTest() {
+    // 동시에 여러 입장 처리 요청
+    CompletableFuture.allOf(
+        IntStream.range(0, 10)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> 
+                waitingService.makeVisit(new WaitingMakeVisitRequest(waitingIds.get(i)))
+            ))
+            .toArray(CompletableFuture[]::new)
+    ).join();
+    
+    // 순번 일관성 검증
+    assertWaitingNumbersConsistent(popupId);
+}
+```
+
+### 성능 테스트
+- 동시 요청 처리량 측정
+- 락 대기시간 모니터링
+- 데드락 발생 빈도 체크
+
+## 모니터링 포인트
+
+1. **성능 지표**
+   - 입장 처리 응답시간
+   - 동시 처리량 (TPS)
+   - 락 획득 대기시간
+
+2. **안정성 지표**
+   - 데드락 발생 횟수
+   - 트랜잭션 실패율
+   - 데이터 일관성 오류
+
+3. **비즈니스 지표**
+   - 순번 재배치 정확도
+   - 사용자 경험 지표
+   - 시스템 가용성

--- a/backend/src/main/java/com/example/demo/application/dto/waiting/WaitingMakeVisitRequest.java
+++ b/backend/src/main/java/com/example/demo/application/dto/waiting/WaitingMakeVisitRequest.java
@@ -1,0 +1,9 @@
+package com.example.demo.application.dto.waiting;
+
+/**
+ * 대기열 입장 처리 요청 DTO
+ */
+public record WaitingMakeVisitRequest(
+        Long waitingId
+) {
+}

--- a/backend/src/main/java/com/example/demo/application/service/ScheduledWaitingEnterService.java
+++ b/backend/src/main/java/com/example/demo/application/service/ScheduledWaitingEnterService.java
@@ -1,0 +1,44 @@
+package com.example.demo.application.service;
+
+import com.example.demo.application.dto.waiting.WaitingMakeVisitRequest;
+import com.example.demo.domain.model.waiting.WaitingQuery;
+import com.example.demo.domain.model.waiting.WaitingStatus;
+import com.example.demo.domain.port.WaitingPort;
+import com.example.demo.infrastructure.persistence.entity.popup.PopupEntity;
+import com.example.demo.infrastructure.persistence.repository.PopupJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+//임시 로직이므로 나중에 삭제 예정
+public class ScheduledWaitingEnterService {
+
+    private final WaitingService waitingService;
+    private final WaitingPort waitingPort;
+    private final PopupJpaRepository popupJpaRepository;
+
+
+    @Scheduled(fixedRate = 5, timeUnit = TimeUnit.MINUTES)
+    @Transactional
+    public void enter() {
+        log.info("ScheduledWaitingEnterService - enter() 실행");
+        List<Long> popupIds = popupJpaRepository.findAll().stream().map(PopupEntity::getId).toList();
+        for (Long popupId : popupIds) {
+            WaitingQuery query = WaitingQuery.forPopup(popupId, WaitingStatus.WAITING);
+            waitingPort.findByQuery(query).stream().filter(
+                    it -> it.waitingNumber() == 0L
+            ).findFirst().ifPresent(waiting -> {
+                waitingService.makeVisit(new WaitingMakeVisitRequest(waiting.id()));
+            });
+        }
+        log.info("ScheduledWaitingEnterService - enter() 완료");
+    }
+}

--- a/backend/src/main/java/com/example/demo/application/service/WaitingService.java
+++ b/backend/src/main/java/com/example/demo/application/service/WaitingService.java
@@ -100,7 +100,7 @@ public class WaitingService {
         
         // waitingId가 있으면 단건 조회
         if (waitingId != null) {
-            Waiting waiting = waitingPort.findByQuery(new WaitingQuery(waitingId, null, null, null, null, null))
+            Waiting waiting = waitingPort.findByQuery(WaitingQuery.forWaitingId(waitingId))
                     .stream()
                     .findFirst()
                     .orElseThrow(() -> new BusinessException(ErrorType.WAITING_NOT_FOUND, String.valueOf(waitingId)));
@@ -138,7 +138,7 @@ public class WaitingService {
     @Transactional
     public void makeVisit(WaitingMakeVisitRequest request) {
         // 1. 대기 정보 조회
-        WaitingQuery query = new WaitingQuery(request.waitingId(), null, null, null, null, null);
+        WaitingQuery query = WaitingQuery.forWaitingId(request.waitingId());
         Waiting waiting = waitingPort.findByQuery(query)
                 .stream()
                 .findFirst()
@@ -147,7 +147,42 @@ public class WaitingService {
         // 2. 입장 처리
         Waiting enteredWaiting = waiting.enter();
 
-        // 3. 저장
+        // 3. 입장 처리된 대기 저장
         waitingPort.save(enteredWaiting);
+
+        // 4. 같은 팝업의 나머지 대기자들 순번 앞당기기
+        reorderWaitingNumbers(waiting.popup().getId(), waiting.waitingNumber());
+    }
+
+    /**
+     * 특정 팝업의 대기 순번을 앞당긴다.
+     * 
+     * @param popupId 팝업 ID
+     * @param enteredWaitingNumber 입장 처리된 대기 번호
+     */
+    private void reorderWaitingNumbers(Long popupId, Integer enteredWaitingNumber) {
+        // 1. 해당 팝업의 모든 대기중인 대기 조회
+        WaitingQuery popupQuery = WaitingQuery.forPopup(popupId, WaitingStatus.WAITING);
+        List<Waiting> waitingList = waitingPort.findByQuery(popupQuery);
+        
+        // 2. 입장 처리된 대기번호보다 큰 번호들만 필터링하여 순번 앞당기기
+        List<Waiting> reorderedWaitings = waitingList.stream()
+                .filter(w -> w.waitingNumber() > enteredWaitingNumber)
+                .map(w -> new Waiting(
+                        w.id(),
+                        w.popup(),
+                        w.waitingPersonName(),
+                        w.member(),
+                        w.contactEmail(),
+                        w.peopleCount(),
+                        w.waitingNumber() - 1,  // 순번 1 감소
+                        w.status(),
+                        w.registeredAt(),
+                        w.enteredAt()
+                ))
+                .toList();
+        
+        // 3. 변경된 대기들 모두 저장
+        reorderedWaitings.forEach(waitingPort::save);
     }
 } 

--- a/backend/src/main/java/com/example/demo/application/service/WaitingService.java
+++ b/backend/src/main/java/com/example/demo/application/service/WaitingService.java
@@ -3,6 +3,7 @@ package com.example.demo.application.service;
 import com.example.demo.application.dto.waiting.VisitHistoryCursorResponse;
 import com.example.demo.application.dto.waiting.WaitingCreateRequest;
 import com.example.demo.application.dto.waiting.WaitingCreateResponse;
+import com.example.demo.application.dto.waiting.WaitingMakeVisitRequest;
 import com.example.demo.application.dto.waiting.WaitingResponse;
 import com.example.demo.application.mapper.WaitingDtoMapper;
 import com.example.demo.common.exception.BusinessException;
@@ -129,5 +130,24 @@ public class WaitingService {
                 .toList();
 
         return new VisitHistoryCursorResponse(waitingResponses, lastId, hasNext);
+    }
+
+    /**
+     * 대기열 입장 처리
+     */
+    @Transactional
+    public void makeVisit(WaitingMakeVisitRequest request) {
+        // 1. 대기 정보 조회
+        WaitingQuery query = new WaitingQuery(request.waitingId(), null, null, null, null, null);
+        Waiting waiting = waitingPort.findByQuery(query)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorType.WAITING_NOT_FOUND, String.valueOf(request.waitingId())));
+
+        // 2. 입장 처리
+        Waiting enteredWaiting = waiting.enter();
+
+        // 3. 저장
+        waitingPort.save(enteredWaiting);
     }
 } 

--- a/backend/src/main/java/com/example/demo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/example/demo/common/exception/ErrorType.java
@@ -9,51 +9,52 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
     // 파라미터 검증 관련
     PARAMETER_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "PARAMETER_VALIDATION_FAILED", "요청 파라미터 검증에 실패했습니다"),
-    
+
     // 페이지네이션 관련 - NotificationService.java:56, 59
     INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "INVALID_PAGE_SIZE", "페이지 크기가 유효하지 않습니다"),
-    
+
     // 정렬/필터 관련 - NotificationService.java:72, 84
     INVALID_READ_STATUS(HttpStatus.BAD_REQUEST, "INVALID_READ_STATUS", "유효하지 않은 읽음 상태입니다"),
     INVALID_SORT_OPTION(HttpStatus.BAD_REQUEST, "INVALID_SORT_OPTION", "유효하지 않은 정렬 옵션입니다"),
-    
+
     // 권한 관련 - NotificationService.java:95, 110, WaitingService.java:107
     ACCESS_DENIED_NOTIFICATION(HttpStatus.FORBIDDEN, "ACCESS_DENIED_NOTIFICATION", "해당 알림에 접근할 권한이 없습니다"),
     ACCESS_DENIED_WAITING(HttpStatus.FORBIDDEN, "ACCESS_DENIED_WAITING", "본인의 대기 정보만 조회할 수 있습니다"),
-    
+
     // 엔티티 미존재 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "사용자를 찾을 수 없습니다"), // MemberController.java:32, NotificationPortAdapter.java:168, ScheduledNotificationPortAdapter.java:110, WaitingService.java:54
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_NOT_FOUND", "알림을 찾을 수 없습니다"), // NotificationPortAdapter.java:61, NotificationService.java:92, 107
     POPUP_NOT_FOUND(HttpStatus.NOT_FOUND, "POPUP_NOT_FOUND", "팝업을 찾을 수 없습니다"), // PopupService.java:66, WaitingService.java:47
     WAITING_NOT_FOUND(HttpStatus.NOT_FOUND, "WAITING_NOT_FOUND", "대기 정보를 찾을 수 없습니다"), // NotificationPortAdapter.java:184, ScheduledNotificationPortAdapter.java:126, WaitingService.java:103
-    
+
     // 도메인 검증 관련
     INVALID_WAITING_STATUS(HttpStatus.BAD_REQUEST, "INVALID_WAITING_STATUS", "유효하지 않은 대기 상태입니다"), // WaitingStatus.java:27
     INVALID_PEOPLE_COUNT(HttpStatus.BAD_REQUEST, "INVALID_PEOPLE_COUNT", "대기 인원수가 유효하지 않습니다"), // Waiting.java:43
     INVALID_WAITING_PERSON_NAME(HttpStatus.BAD_REQUEST, "INVALID_WAITING_PERSON_NAME", "대기자 이름이 유효하지 않습니다"), // Waiting.java:46, 49
     INVALID_OPENING_HOURS(HttpStatus.BAD_REQUEST, "INVALID_OPENING_HOURS", "운영 시간이 유효하지 않습니다"), // OpeningHours.java:20, WeeklyOpeningHours.java:25
     INVALID_POPUP_TYPE(HttpStatus.BAD_REQUEST, "INVALID_POPUP_TYPE", "지원하지 않는 팝업 타입입니다"), // PopupType.java:37
-    
+    WAITING_NOT_READY(HttpStatus.BAD_REQUEST, "WAITING_NOT_READY", "아직 입장할 수 없습니다."),
+
     // 데이터 무결성 관련
     NULL_NOTIFICATION_ID(HttpStatus.BAD_REQUEST, "NULL_NOTIFICATION_ID", "알림 ID가 null입니다"), // NotificationPortAdapter.java:50
     INVALID_SOURCE_DOMAIN(HttpStatus.BAD_REQUEST, "INVALID_SOURCE_DOMAIN", "유효하지 않은 소스 도메인입니다"), // NotificationPortAdapter.java:176, ScheduledNotificationPortAdapter.java:118
     UNSUPPORTED_NOTIFICATION_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "UNSUPPORTED_NOTIFICATION_TYPE", "지원하지 않는 알림 타입입니다"), // NotificationDtoMapper.java:62, NotificationPortAdapter.java:142, ScheduledNotificationPortAdapter.java:77, NotificationEntityMapper.java:123
-    
+
     // 인증 관련
     AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTHENTICATION_REQUIRED", "인증이 필요합니다"), // MemberController.java:31
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다"),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다"),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "접근이 거부되었습니다"),
     OAUTH_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH_MEMBER_NOT_FOUND", "OAuth 계정과 연결된 회원을 찾을 수 없습니다"), // OAuth2Service.java:52
-    
+
     // 외부 API 연동 관련
     OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "OAUTH_TOKEN_REQUEST_FAILED", "OAuth 토큰 요청에 실패했습니다"), // OAuth2Service.java:81
     OAUTH_USER_INFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "OAUTH_USER_INFO_REQUEST_FAILED", "OAuth 사용자 정보 요청에 실패했습니다"), // OAuth2Service.java:96
     OAUTH_ERROR_RECEIVED(HttpStatus.BAD_REQUEST, "OAUTH_ERROR_RECEIVED", "OAuth 인증 과정에서 오류가 발생했습니다"), // OAuthController.java:35
-    
+
     // 시스템 설정 관련
     SYSTEM_CONFIGURATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYSTEM_CONFIGURATION_ERROR", "시스템 설정 오류입니다"), // NotificationEntityMapper.java:92
-    
+
     // 미구현 기능 관련
     FEATURE_NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED, "FEATURE_NOT_IMPLEMENTED", "아직 구현되지 않은 기능입니다"); // PopupPortAdapter.java:72
 

--- a/backend/src/main/java/com/example/demo/domain/model/waiting/Waiting.java
+++ b/backend/src/main/java/com/example/demo/domain/model/waiting/Waiting.java
@@ -23,7 +23,8 @@ public record Waiting(
         Integer peopleCount,
         Integer waitingNumber,
         WaitingStatus status,
-        LocalDateTime registeredAt
+        LocalDateTime registeredAt,
+        LocalDateTime enteredAt
 ) {
     private static final Pattern NAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣0-9][a-zA-Z가-힣0-9]*$");
 
@@ -38,6 +39,7 @@ public record Waiting(
      * @param waitingNumber     대기 번호
      * @param status            대기 상태
      * @param registeredAt      등록 시간
+     * @param enteredAt         입장 시간
      * @throws IllegalArgumentException 유효하지 않은 인원수인 경우
      */
     public Waiting {
@@ -50,5 +52,46 @@ public record Waiting(
         if (!NAME_PATTERN.matcher(waitingPersonName).matches()) {
             throw new BusinessException(ErrorType.INVALID_WAITING_PERSON_NAME, waitingPersonName);
         }
+    }
+
+    /**
+     * 기존 필드만으로 대기 정보를 생성한다.
+     *
+     * @param id                대기 ID
+     * @param popup             팝업 정보
+     * @param waitingPersonName 대기자 이름
+     * @param member            회원 정보
+     * @param contactEmail      대기자 이메일
+     * @param peopleCount       대기 인원수
+     * @param waitingNumber     대기 번호
+     * @param status            대기 상태
+     * @param registeredAt      등록 시간
+     */
+    public Waiting(
+            Long id,
+            Popup popup,
+            String waitingPersonName,
+            Member member,
+            String contactEmail,
+            Integer peopleCount,
+            Integer waitingNumber,
+            WaitingStatus status,
+            LocalDateTime registeredAt
+    ) {
+        this(id, popup, waitingPersonName, member, contactEmail, peopleCount, waitingNumber, status, registeredAt, null);
+    }
+
+    /**
+     * 입장 처리를 수행한다.
+     *
+     * @return 입장 시간이 설정된 새로운 Waiting 객체
+     * @throws BusinessException 대기중 상태가 아닌 경우
+     */
+    public Waiting enter() {
+        if (status != WaitingStatus.WAITING) {
+            throw new BusinessException(ErrorType.INVALID_WAITING_STATUS, status.toString());
+        }
+        return new Waiting(id, popup, waitingPersonName, member, contactEmail, peopleCount,
+                waitingNumber, WaitingStatus.VISITED, registeredAt, LocalDateTime.now());
     }
 }

--- a/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingQuery.java
+++ b/backend/src/main/java/com/example/demo/domain/model/waiting/WaitingQuery.java
@@ -12,7 +12,8 @@ public record WaitingQuery(
         Integer size,
         Long lastWaitingId,
         WaitingStatus status,
-        SortOrder sortOrder
+        SortOrder sortOrder,
+        Long popupId
 ) {
 
     /**
@@ -29,14 +30,14 @@ public record WaitingQuery(
      * 첫 페이지 조회용 생성자 (기본 정렬: RESERVED_FIRST_THEN_DATE_DESC)
      */
     public static WaitingQuery firstPage(Long memberId, Integer size) {
-        return new WaitingQuery(null, memberId, size, null, null, SortOrder.RESERVED_FIRST_THEN_DATE_DESC);
+        return new WaitingQuery(null, memberId, size, null, null, SortOrder.RESERVED_FIRST_THEN_DATE_DESC, null);
     }
 
     /**
      * 상태 필터링이 포함된 조회용 생성자 (기본 정렬: RESERVED_FIRST_THEN_DATE_DESC)
      */
     public static WaitingQuery withStatus(Long memberId, Integer size, WaitingStatus status) {
-        return new WaitingQuery(null, memberId, size, null, status, SortOrder.RESERVED_FIRST_THEN_DATE_DESC);
+        return new WaitingQuery(null, memberId, size, null, status, SortOrder.RESERVED_FIRST_THEN_DATE_DESC, null);
     }
 
     /**
@@ -51,7 +52,7 @@ public record WaitingQuery(
      */
     public static WaitingQuery forVisitHistory(Long memberId, Integer size, Long lastWaitingId, String status) {
         return Optional.ofNullable(lastWaitingId)
-                .map(id -> new WaitingQuery(null, memberId, size, id, WaitingStatus.fromString(status), SortOrder.RESERVED_FIRST_THEN_DATE_DESC))
+                .map(id -> new WaitingQuery(null, memberId, size, id, WaitingStatus.fromString(status), SortOrder.RESERVED_FIRST_THEN_DATE_DESC, null))
                 .orElseGet(() -> Optional.ofNullable(WaitingStatus.fromString(status))
                         .map(waitingStatus -> withStatus(memberId, size, waitingStatus))
                         .orElse(firstPage(memberId, size))
@@ -59,6 +60,17 @@ public record WaitingQuery(
     }
 
     public static WaitingQuery forWaitingId(Long waitingId) {
-        return new WaitingQuery(waitingId, null, null, null, null, null);
+        return new WaitingQuery(waitingId, null, null, null, null, null, null);
+    }
+
+    /**
+     * 팝업별 대기 조회용 생성자
+     */
+    public static WaitingQuery forPopup(Long popupId, WaitingStatus status) {
+        return new WaitingQuery(null, null, null, null, status, null, popupId);
+    }
+
+    public WaitingQuery(Long waitingId, Long memberId, Integer size, Long lastWaitingId, WaitingStatus status, SortOrder sortOrder) {
+        this(waitingId, memberId, size, lastWaitingId, status, sortOrder, null);
     }
 } 

--- a/backend/src/main/java/com/example/demo/domain/port/WaitingPort.java
+++ b/backend/src/main/java/com/example/demo/domain/port/WaitingPort.java
@@ -37,5 +37,6 @@ public interface WaitingPort {
      */
     Integer getNextWaitingNumber(Long popupId);
     Optional<Waiting> findByMemberIdAndPopupId(Long memberId, Long popupId);
+
     
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/WaitingPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/WaitingPortAdapter.java
@@ -45,6 +45,16 @@ public class WaitingPortAdapter implements WaitingPort {
                     .collect(Collectors.toList());
         }
 
+        // 팝업별 대기 조회
+        if (query.popupId() != null) {
+            List<WaitingEntity> entities = waitingJpaRepository.findByPopupIdAndStatusOrderByWaitingNumber(
+                    query.popupId(), query.status());
+            return entities.stream()
+                    .map(this::mapEntityToDomain)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        }
+
         List<WaitingEntity> waitingEntities = switch (query.sortOrder()) {
             case RESERVED_FIRST_THEN_DATE_DESC ->
                     waitingJpaRepository.findByMemberIdOrderByStatusReservedFirstThenCreatedAtDesc(
@@ -81,4 +91,5 @@ public class WaitingPortAdapter implements WaitingPort {
                 return Optional.of(waitingEntityMapper.toDomain(entity, popup, member));
             });
     }
+
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/WaitingPortAdapter.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/WaitingPortAdapter.java
@@ -7,13 +7,14 @@ import com.example.demo.domain.port.WaitingPort;
 import com.example.demo.infrastructure.persistence.entity.WaitingEntity;
 import com.example.demo.infrastructure.persistence.mapper.WaitingEntityMapper;
 import com.example.demo.infrastructure.persistence.repository.WaitingJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -47,7 +48,7 @@ public class WaitingPortAdapter implements WaitingPort {
 
         // 팝업별 대기 조회
         if (query.popupId() != null) {
-            List<WaitingEntity> entities = waitingJpaRepository.findByPopupIdAndStatusOrderByWaitingNumber(
+            List<WaitingEntity> entities = waitingJpaRepository.findByPopupIdAndStatusOrderByWaitingNumberAsc(
                     query.popupId(), query.status());
             return entities.stream()
                     .map(this::mapEntityToDomain)
@@ -84,12 +85,12 @@ public class WaitingPortAdapter implements WaitingPort {
     @Override
     public Optional<Waiting> findByMemberIdAndPopupId(Long memberId, Long popupId) {
         return waitingJpaRepository.findByMemberIdAndPopupId(memberId, popupId)
-            .flatMap(entity -> {
-                var popup = popupPortAdapter.findById(entity.getPopupId()).orElse(null);
-                var member = memberPortAdapter.findById(entity.getMemberId()).orElse(null);
-                if (popup == null || member == null) return Optional.empty();
-                return Optional.of(waitingEntityMapper.toDomain(entity, popup, member));
-            });
+                .flatMap(entity -> {
+                    var popup = popupPortAdapter.findById(entity.getPopupId()).orElse(null);
+                    var member = memberPortAdapter.findById(entity.getMemberId()).orElse(null);
+                    if (popup == null || member == null) return Optional.empty();
+                    return Optional.of(waitingEntityMapper.toDomain(entity, popup, member));
+                });
     }
 
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/WaitingEntityMapper.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/mapper/WaitingEntityMapper.java
@@ -42,6 +42,7 @@ public class WaitingEntityMapper {
      */
     public WaitingEntity toEntity(Waiting waiting) {
         return WaitingEntity.builder()
+                .id(waiting.id())
                 .popupId(waiting.popup().getId())
                 .memberId(waiting.member().id())
                 .waitingPersonName(waiting.waitingPersonName())

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/WaitingJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/WaitingJpaRepository.java
@@ -48,8 +48,8 @@ public interface WaitingJpaRepository extends JpaRepository<WaitingEntity, Long>
      * 특정 팝업의 대기중인 모든 대기를 대기번호 순으로 조회한다.
      *
      * @param popupId 팝업 ID
-     * @param status 대기 상태
+     * @param status  대기 상태
      * @return 대기 엔티티 목록 (대기번호 순으로 정렬)
      */
-    List<WaitingEntity> findByPopupIdAndStatusOrderByWaitingNumber(Long popupId, WaitingStatus status);
+    List<WaitingEntity> findByPopupIdAndStatusOrderByWaitingNumberAsc(Long popupId, WaitingStatus status);
 } 

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/WaitingJpaRepository.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/repository/WaitingJpaRepository.java
@@ -43,4 +43,13 @@ public interface WaitingJpaRepository extends JpaRepository<WaitingEntity, Long>
     Optional<Integer> findMaxWaitingNumberByPopupId(@Param("popupId") Long popupId);
 
     Optional<WaitingEntity> findByMemberIdAndPopupId(Long memberId, Long popupId);
+
+    /**
+     * 특정 팝업의 대기중인 모든 대기를 대기번호 순으로 조회한다.
+     *
+     * @param popupId 팝업 ID
+     * @param status 대기 상태
+     * @return 대기 엔티티 목록 (대기번호 순으로 정렬)
+     */
+    List<WaitingEntity> findByPopupIdAndStatusOrderByWaitingNumber(Long popupId, WaitingStatus status);
 } 

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -93,8 +93,8 @@ VALUES (1, 1, 1000, 4, '좋아요'),
 
 INSERT INTO waitings (id, popup_id, waiting_person_name, member_id, contact_email, people_count, waiting_number, status,
                       created_at, modified_at)
-VALUES (100, 1, '김테스트', 1000, 'test@test.com', 2, 1, 'WAITING', '2025-06-28T10:00:00', '2025-06-28T10:00:00'),
-       (101, 1, '이테스트', 1001, 'test2@test.com', 1, 2, 'WAITING', '2025-06-28T11:00:00', '2025-06-28T11:00:00');
+VALUES (100, 1, '김테스트', 1000, 'test@test.com', 2, 0, 'WAITING', '2025-06-28T10:00:00', '2025-06-28T10:00:00'),
+       (101, 1, '이테스트', 1001, 'test2@test.com', 1, 1, 'WAITING', '2025-06-28T11:00:00', '2025-06-28T11:00:00');
 
 -- ===================================
 -- ✅ [DATA] notifications

--- a/backend/src/test/java/com/example/demo/domain/model/waiting/WaitingTest.java
+++ b/backend/src/test/java/com/example/demo/domain/model/waiting/WaitingTest.java
@@ -264,4 +264,84 @@ class WaitingTest {
                 validEmail, 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
         ));
     }
+
+    @Test
+    @DisplayName("입장 처리 테스트 - 정상적인 입장")
+    public void test05() {
+        // given
+        Waiting waiting = new Waiting(
+                1L, validPopup, "홍길동", validMember,
+                "test@example.com", 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
+        );
+        
+        // when
+        Waiting enteredWaiting = waiting.enter();
+        
+        // then
+        assertNotNull(enteredWaiting.enteredAt());
+        assertEquals(WaitingStatus.VISITED, enteredWaiting.status());
+        assertEquals(waiting.id(), enteredWaiting.id());
+        assertEquals(waiting.popup(), enteredWaiting.popup());
+        assertEquals(waiting.waitingPersonName(), enteredWaiting.waitingPersonName());
+        assertEquals(waiting.member(), enteredWaiting.member());
+        assertEquals(waiting.contactEmail(), enteredWaiting.contactEmail());
+        assertEquals(waiting.peopleCount(), enteredWaiting.peopleCount());
+        assertEquals(waiting.waitingNumber(), enteredWaiting.waitingNumber());
+        assertEquals(waiting.registeredAt(), enteredWaiting.registeredAt());
+    }
+
+    @Test
+    @DisplayName("입장 처리 테스트 - 입장 시간이 현재 시간과 유사한지 확인")
+    public void test05_2() {
+        // given
+        Waiting waiting = new Waiting(
+                1L, validPopup, "홍길동", validMember,
+                "test@example.com", 2, 1, WaitingStatus.WAITING, LocalDateTime.now()
+        );
+        LocalDateTime beforeEnter = LocalDateTime.now();
+        
+        // when
+        Waiting enteredWaiting = waiting.enter();
+        
+        // then
+        LocalDateTime afterEnter = LocalDateTime.now();
+        assertNotNull(enteredWaiting.enteredAt());
+        assertTrue(enteredWaiting.enteredAt().isAfter(beforeEnter.minusSeconds(1)));
+        assertTrue(enteredWaiting.enteredAt().isBefore(afterEnter.plusSeconds(1)));
+    }
+
+    @Test
+    @DisplayName("입장 처리 테스트 - 이미 방문 완료된 상태에서 입장 (예외 발생)")
+    public void test05_3() {
+        // given
+        LocalDateTime originalEnteredAt = LocalDateTime.now().minusHours(1);
+        Waiting alreadyVisitedWaiting = new Waiting(
+                1L, validPopup, "홍길동", validMember,
+                "test@example.com", 2, 1, WaitingStatus.VISITED, LocalDateTime.now(), originalEnteredAt
+        );
+        
+        // when & then
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> alreadyVisitedWaiting.enter()
+        );
+        assertEquals(ErrorType.INVALID_WAITING_STATUS, exception.getErrorType());
+    }
+
+    @Test
+    @DisplayName("입장 처리 테스트 - 취소된 상태에서 입장 (예외 발생)")
+    public void test05_4() {
+        // given
+        Waiting canceledWaiting = new Waiting(
+                1L, validPopup, "홍길동", validMember,
+                "test@example.com", 2, 1, WaitingStatus.CANCELED, LocalDateTime.now()
+        );
+        
+        // when & then
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> canceledWaiting.enter()
+        );
+        assertEquals(ErrorType.INVALID_WAITING_STATUS, exception.getErrorType());
+    }
 }


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #146 

## 변경사항 설명
- 현장 대기 입장 기능 구현
  - 입장 시 같은 팝업의 다른 현장대기의 순번을 앞당김.
  - 순번이 0인 대기만 입장 가능 

## 일정
- 리뷰 요청 기한: 2025-08-07
- 머지 예정일: 2025-08-08


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 현장 대기 입장 시키는 스케줄링 코드는 임시 로직이므로 아키텍처 원칙 무시하고 대충 작성했습니다.
- 성능 관련: 
- 보안 관련: 
- 기타: 

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. 어플리케이션 실행 직후 현장대기 하나가 입장 상태로 전환되는지 확인(h2-console)
2. 5분 후 나머지 현장대기 하나도 입장 상태로 전환되는지 확인

## 체크리스트
- [x] 테스트 코드를 작성했나요?
- [x] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.

## 추가 정보
- MVP 이후에는 여러 코드 작성 규칙을 정한 뒤 작업을 진행해야 할 듯 합니다.
  - 정한 이후에는 AI 를 위해 규칙을 코드베이스에 적어두는게 좋을 듯 합니다. 