### PR TITLE
fix: 운영환경별 cors 허용 설정

### DIFF
--- a/backend/src/main/java/com/example/demo/config/AppProperties.java
+++ b/backend/src/main/java/com/example/demo/config/AppProperties.java
@@ -4,9 +4,12 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "custom.app")
 public class AppProperties {
     private String frontendUrl;
+    private List<String> corsAllowedOrigins;
 } 

--- a/backend/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -67,8 +67,8 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // application.yml에서 설정된 frontend-url 사용
-        configuration.setAllowedOrigins(Arrays.asList(appProperties.getFrontendUrl(), "https://api.spotit.co.kr"));
+        // application.yml에서 설정된 CORS 허용 도메인들 사용
+        configuration.setAllowedOrigins(appProperties.getCorsAllowedOrigins());
 
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(Arrays.asList("*"));

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -19,3 +19,8 @@ spring:
       hibernate:
         format_sql: false
         default_batch_fetch_size: 1000
+
+custom:
+  app:
+    cors-allowed-origins:
+      - https://dev.api.spotit.co.kr

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -27,3 +27,8 @@ logging:
     org.hibernate.SQL: INFO
     org.hibernate.type.descriptor.sql.BasicBinder: INFO
     org.springframework.jdbc.datasource.init.ScriptUtils: DEBUG
+
+custom:
+  app:
+    cors-allowed-origins:
+      - http://localhost:3000

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -33,3 +33,6 @@ custom:
   metrics:
     userName: ${METRICS_USER}
     password: ${METRICS_PASSWORD}
+  app:
+    cors-allowed-origins:
+      - https://api.spotit.co.kr


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #133 

## 변경사항 설명
- 운영 환경별 cors 허용 설정 수정
- AppProperties에 corsAllowedOrigins 리스트 추가
- 하드코딩된 CORS 설정을 외부 설정으로 변경
- 환경별 CORS 허용 도메인 최적화:
  - 로컬: localhost 도메인들만 허용
  - 개발: dev.api.spotit.co.kr만 허용
  - 운영: api.spotit.co.kr만 허용
  
- 리뷰 요청 기한: 2025-09-01
- 머지 예정일: 2025-09-01


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: 

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. '...' 페이지로 이동
2. '....' 버튼 클릭
3. '....' 결과 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.

## 추가 정보
추가적인 정보나 컨텍스트가 있다면 여기에 작성해주세요. 