### PR TITLE
Feat/#283/fe : 운영/개발환경 별 로깅하는 모듈 생성

### DIFF
--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -7,3 +7,4 @@ export { default as ReactQueryClientProvider } from './ReactQueryClientProvider'
 export { useGetMapBounds } from './useGetMapBounds';
 export { default as GTMInit } from './GTMInit';
 export { default as extractLinkMetaFromButton } from './extractLinkMetaFromButton';
+export { default as logger } from './logger';

--- a/frontend/src/shared/lib/logError.ts
+++ b/frontend/src/shared/lib/logError.ts
@@ -1,8 +1,9 @@
 import { ApiError } from '@/shared/type/api';
+import { logger } from '@/shared/lib/index';
 
 export default function logError(error: ApiError, context = '') {
   if (context) {
-    console.error(`${context} 에서 에러가 발생하였습니다.`);
+    logger.error(`${context} 에서 에러가 발생하였습니다.`);
   }
-  console.error(`${error.message}`);
+  logger.error(`${error.message}`);
 }

--- a/frontend/src/shared/lib/logger.ts
+++ b/frontend/src/shared/lib/logger.ts
@@ -1,0 +1,41 @@
+type ConsoleArgs = Parameters<typeof console.log>;
+type levelType = 'debug' | 'warn' | 'error' | 'info';
+
+/**
+  [사용방법]
+  logger.debug('개발시 디버깅하고 싶은 것들..');
+  logger.warn('경고 문구');
+ */
+
+const logger = {
+  debug: (...args: ConsoleArgs) => log('debug', ...args),
+  warn: (...args: ConsoleArgs) => log('warn', ...args),
+  error: (...args: ConsoleArgs) => log('error', ...args),
+  info: (...args: ConsoleArgs) => log('info', ...args),
+};
+
+const log = (level: levelType, ...args: ConsoleArgs) => {
+  if (!shouldLog(level)) return;
+  const method = level === 'debug' ? 'log' : level;
+  console[method](...args);
+};
+
+// NEXT_PUBLIC_LOG_LEVEL = silent, prod, dev
+// NEXT_PUBLIC_ENV = PRODUCTION, DEVELOP
+const LOG_LEVEL = process.env.NEXT_PUBLIC_LOG_LEVEL || 'dev';
+const isProduction = process.env.NEXT_PUBLIC_ENV === 'PRODUCTION';
+const shouldLog = (level: string) => {
+  if (LOG_LEVEL === 'silent') {
+    // 운영환경 완전 무음
+    return !isProduction;
+  }
+
+  if (LOG_LEVEL === 'prod') {
+    // 운영환경은 warn/error만 출력
+    return !(isProduction && (level === 'debug' || level === 'info'));
+  }
+
+  // dev 모드 → 항상 로그 출력
+  return true;
+};
+export default logger;


### PR DESCRIPTION
## 관련 이슈
close #283 

## 변경사항 설명
- 운영 환경에서 불필요한 console.log 출력으로 인한 보안 문제를 방지하고, 개발 환경에서만 상세 로그를 확인할 수 있도록 공용 로깅 모듈을 추가
- shared/lib/logger.ts 추가
  -  logger.debug | logger.info | logger.warn | logger.error 4단계 레벨 지원
  - process.env.NEXT_PUBLIC_NODE_ENV와 NEXT_PUBLIC_LOG_LEVEL 기반으로 출력 제어
  - NEXT_PUBLIC_LOG_LEVEL = silent, prod, dev
  - NEXT_PUBLIC_ENV = PRODUCTION, DEVELOP
  - NEXT_PUBLIC_NODE_ENV ===  DEVELOP 일 경우 : 모든 로그 출력 (local, 개발 환경)
  - NEXT_PUBLIC_NODE_ENV === PRODUCTION 일 경우 LOG_LEVEL을 통해 출력 조절 (토글 역할)
    - NEXT_PUBLIC_LOG_LEVEL === silent: 운영 환경에서 모든 로그 비활성화
    - NEXT_PUBLIC_LOG_LEVEL === prod : 운영 환경에서 warn/error만 출력
   
## 일정
- 리뷰 요청 기한: 2025-09-11
- 머지 예정일: 2025-09-11

## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: 
  - 인터페이스가 사용하기에 직관적인지 확인해주세요.
  - NEXT_PUBLIC_LOG_LEVEL로 운영환경에서 출력레벨을 조절하는것이 적합하다고 생각하는지 궁금합니다!, 운영환경에서는 깔끔하게 아무 로그도 표시되지 않고 에러만 sentry로 기록하는 방식도 좋은 것 같아서 고민이 됩니다.

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. '...' 페이지로 이동
2. '....' 버튼 클릭
3. '....' 결과 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷


## 추가 정보
- 사용 방법은 상단 주석 참고바랍니다.
- logError.ts 변경사항 처럼, 해당 모듈이 추가된다면 기존의 console~을 대체하는 작업이 필요합니다.