### PR TITLE
Feat/#292/fe : 낙관적 업데이트로 알림삭제

### DIFF
--- a/frontend/src/features/notification/hook/useDeleteNotification.ts
+++ b/frontend/src/features/notification/hook/useDeleteNotification.ts
@@ -3,21 +3,99 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import deleteNotificationApi from '@/features/notification/api/deleteNotificationApi';
 import { toast } from 'sonner';
+import NotificationType from '@/features/notification/type/Notification';
+import { logger } from '@/shared/lib';
+
+const NOTIFICATION_LIST_QUERY_KEY = [
+  'notification',
+  'list',
+  { readStatus: 'ALL', sort: 'UNREAD_FIRST' },
+] as const;
+
+type NotificationListData = {
+  pages: {
+    content: NotificationType[];
+    hasNext: boolean;
+    lastNotificationId: number;
+  }[];
+  pageParams: unknown[];
+};
 
 export default function useDeleteNotification() {
   const queryClient = useQueryClient();
-  return useMutation({
+  return useMutation<
+    unknown, // TData (delete API 응답, 지금은 신경 안 씀)
+    Error, // TError
+    number, // TVariables (notificationId)
+    { prevData?: NotificationListData } // TContext
+  >({
     retry: false,
     mutationFn: (notificationId: number) =>
       deleteNotificationApi({ notificationId }),
-    onError: error => {
-      console.error('[onError]:', error.message);
+    // mutationFn이 호출되기 지직전에 실행됨
+    onMutate: async (notificationId: number) => {
+      performance.mark(`delete_${notificationId}_start`);
+      // 1. 현재 쿼리 백업
+      const prevData = queryClient.getQueryData<NotificationListData>(
+        NOTIFICATION_LIST_QUERY_KEY
+      );
+
+      // 2. 알림 목록에서 해당 ID를 제거
+      if (prevData) {
+        queryClient.setQueryData(NOTIFICATION_LIST_QUERY_KEY, {
+          ...prevData,
+          pages: prevData.pages.map(page => ({
+            ...page,
+            content: page.content.filter(
+              n => n.notificationId !== notificationId
+            ),
+          })),
+        });
+      }
+
+      performance.mark(`delete_${notificationId}_end`);
+      performance.measure(
+        `delete_${notificationId}_perceived_latency`,
+        `delete_${notificationId}_start`,
+        `delete_${notificationId}_end`
+      );
+
+      const duration = performance
+        .getEntriesByName(`delete_${notificationId}_perceived_latency`)
+        .at(-1)?.duration;
+
+      console.log(`[Perf] perceived latency: ${duration} ms`);
+
+      // 3. 에러시 롤백
+      return { prevData };
+    },
+    onError: (error, notificationId, context) => {
+      logger.error('[onError]:', error.message);
       toast.error('알림 삭제에 실패했습니다.');
+
+      if (context?.prevData) {
+        queryClient.setQueryData(NOTIFICATION_LIST_QUERY_KEY, context.prevData);
+      }
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['notification', 'list'],
+        queryKey: NOTIFICATION_LIST_QUERY_KEY,
       });
+    },
+    // onSettled: refetch 완료 후 호출됨
+    onSettled: (data, error, notificationId) => {
+      performance.mark(`delete_${notificationId}_consistency_end`);
+      performance.measure(
+        `delete_${notificationId}_consistency_latency`,
+        `delete_${notificationId}_start`,
+        `delete_${notificationId}_consistency_end`
+      );
+
+      const duration = performance
+        .getEntriesByName(`delete_${notificationId}_consistency_latency`)
+        .at(-1)?.duration;
+
+      console.log(`[Perf] consistency latency: ${duration} ms`);
     },
   });
 }

--- a/frontend/src/features/notification/hook/useDeleteNotification.ts
+++ b/frontend/src/features/notification/hook/useDeleteNotification.ts
@@ -34,7 +34,6 @@ export default function useDeleteNotification() {
       deleteNotificationApi({ notificationId }),
     // mutationFn이 호출되기 지직전에 실행됨
     onMutate: async (notificationId: number) => {
-      performance.mark(`delete_${notificationId}_start`);
       // 1. 현재 쿼리 백업
       const prevData = queryClient.getQueryData<NotificationListData>(
         NOTIFICATION_LIST_QUERY_KEY
@@ -53,19 +52,6 @@ export default function useDeleteNotification() {
         });
       }
 
-      performance.mark(`delete_${notificationId}_end`);
-      performance.measure(
-        `delete_${notificationId}_perceived_latency`,
-        `delete_${notificationId}_start`,
-        `delete_${notificationId}_end`
-      );
-
-      const duration = performance
-        .getEntriesByName(`delete_${notificationId}_perceived_latency`)
-        .at(-1)?.duration;
-
-      console.log(`[Perf] perceived latency: ${duration} ms`);
-
       // 3. 에러시 롤백
       return { prevData };
     },
@@ -81,21 +67,6 @@ export default function useDeleteNotification() {
       await queryClient.invalidateQueries({
         queryKey: NOTIFICATION_LIST_QUERY_KEY,
       });
-    },
-    // onSettled: refetch 완료 후 호출됨
-    onSettled: (data, error, notificationId) => {
-      performance.mark(`delete_${notificationId}_consistency_end`);
-      performance.measure(
-        `delete_${notificationId}_consistency_latency`,
-        `delete_${notificationId}_start`,
-        `delete_${notificationId}_consistency_end`
-      );
-
-      const duration = performance
-        .getEntriesByName(`delete_${notificationId}_consistency_latency`)
-        .at(-1)?.duration;
-
-      console.log(`[Perf] consistency latency: ${duration} ms`);
     },
   });
 }

--- a/frontend/src/features/notification/ui/NotificationCardList.tsx
+++ b/frontend/src/features/notification/ui/NotificationCardList.tsx
@@ -22,44 +22,10 @@ export default function NotificationCardList() {
   const handleDeleteClick = (notification: NotificationType) => {
     const { notificationId } = notification;
 
-    // 1. 클릭 시작
-    //performance.mark(`notification_delete_${notificationId}_start`);
-
     // 2.상태 없데이트
     currentDeleteIdRef.current = notificationId; // 현재 삭제할 알림id 기록
     deleteNotification(notificationId);
   };
-
-  // refetch 된 이후 ui 갱신 시점
-  // useEffect(() => {
-  //   if (data) {
-  //     const deleteId = currentDeleteIdRef.current;
-  //     const stillExists = data.content.some(
-  //       noti => noti.notificationId === deleteId
-  //     );
-  //
-  //     if (deleteId && !stillExists) {
-  //       performance.mark(`notification_delete_${deleteId}_end`);
-  //       performance.measure(
-  //         `notification_delete_${deleteId}_latency`,
-  //         `notification_delete_${deleteId}_start`,
-  //         `notification_delete_${deleteId}_end`
-  //       );
-  //
-  //       const entries = performance.getEntriesByName(
-  //         `notification_delete_${deleteId}_latency`
-  //       );
-  //
-  //       const duration = entries[0]?.duration;
-  //
-  //       if (duration) {
-  //         console.log(
-  //           `[Perf] Notification ${deleteId} delete latency: ${duration} ms`
-  //         );
-  //       }
-  //     }
-  //   }
-  // }, [data]);
 
   return (
     <div className="flex flex-col">

--- a/frontend/src/features/notification/ui/NotificationCardList.tsx
+++ b/frontend/src/features/notification/ui/NotificationCardList.tsx
@@ -5,7 +5,7 @@ import { useIntersectionObserver } from '@/shared/hook/useIntersectionObserver';
 import NotificationCardListView from '@/features/notification/ui/NotificationCardListView';
 import useDeleteNotification from '@/features/notification/hook/useDeleteNotification';
 import NotificationType from '@/features/notification/type/Notification';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 export default function NotificationCardList() {
   const currentDeleteIdRef = useRef<number | null>(null);
@@ -23,7 +23,7 @@ export default function NotificationCardList() {
     const { notificationId } = notification;
 
     // 1. 클릭 시작
-    performance.mark(`notification_delete_${notificationId}_start`);
+    //performance.mark(`notification_delete_${notificationId}_start`);
 
     // 2.상태 없데이트
     currentDeleteIdRef.current = notificationId; // 현재 삭제할 알림id 기록
@@ -31,35 +31,35 @@ export default function NotificationCardList() {
   };
 
   // refetch 된 이후 ui 갱신 시점
-  useEffect(() => {
-    if (data) {
-      const deleteId = currentDeleteIdRef.current;
-      const stillExists = data.content.some(
-        noti => noti.notificationId === deleteId
-      );
-
-      if (deleteId && !stillExists) {
-        performance.mark(`notification_delete_${deleteId}_end`);
-        performance.measure(
-          `notification_delete_${deleteId}_latency`,
-          `notification_delete_${deleteId}_start`,
-          `notification_delete_${deleteId}_end`
-        );
-
-        const entries = performance.getEntriesByName(
-          `notification_delete_${deleteId}_latency`
-        );
-
-        const duration = entries[0]?.duration;
-
-        if (duration) {
-          console.log(
-            `[Perf] Notification ${deleteId} delete latency: ${duration} ms`
-          );
-        }
-      }
-    }
-  }, [data]);
+  // useEffect(() => {
+  //   if (data) {
+  //     const deleteId = currentDeleteIdRef.current;
+  //     const stillExists = data.content.some(
+  //       noti => noti.notificationId === deleteId
+  //     );
+  //
+  //     if (deleteId && !stillExists) {
+  //       performance.mark(`notification_delete_${deleteId}_end`);
+  //       performance.measure(
+  //         `notification_delete_${deleteId}_latency`,
+  //         `notification_delete_${deleteId}_start`,
+  //         `notification_delete_${deleteId}_end`
+  //       );
+  //
+  //       const entries = performance.getEntriesByName(
+  //         `notification_delete_${deleteId}_latency`
+  //       );
+  //
+  //       const duration = entries[0]?.duration;
+  //
+  //       if (duration) {
+  //         console.log(
+  //           `[Perf] Notification ${deleteId} delete latency: ${duration} ms`
+  //         );
+  //       }
+  //     }
+  //   }
+  // }, [data]);
 
   return (
     <div className="flex flex-col">


### PR DESCRIPTION
## 관련 이슈
close #292 

## 변경사항 설명
- 알림목록에서의 알림 삭제 동작을 낙관적 업데이트 방식을 사용하여 사용자 체감 반응성을 높였습니다.
- 기존 방식 : 삭제 버튼 클릭 -> 알림 삭제 api 호출 -> 성공적인 응답 수신 -> UI 변경
- 변경된 방식 : 삭제 버튼 클릭 -> UI 변경 -> 알림 삭제 API 호출 -> 실패 응답 수신시에만 롤백

## 일정
- 리뷰 요청 기한: 2025-09-15
- 머지 예정일: 2025-09-15

## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: 

## 테스트 방법
1. git checkout 753a96a // [알림 삭제에 낙관적 업데이트 적용 및 퍼포먼스 측정] 커밋으로 이동
2. npm run dev
3. 알림 삭제 후 콘솔을 확인하거나, 퍼포먼스 탭에서 삭제녹화 후 perceived_latency, consistency_latency 확인

## 체크리스트
- [x] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

