### PR TITLE
Feat/#297/fe : 브라우저 히스토리 정리

### DIFF
--- a/frontend/src/app/(app)/(auth)/login/fail/page.tsx
+++ b/frontend/src/app/(app)/(auth)/login/fail/page.tsx
@@ -45,7 +45,7 @@ export default async function LoginFailPage({
           다시 로그인
         </Link>
         <Link
-          href="/frontend/public"
+          href="/"
           className="border border-gray-300 text-gray-700 px-4 py-2 rounded-md text-sm hover:bg-gray-100 transition"
         >
           홈으로

--- a/frontend/src/app/(app)/(auth)/login/page.tsx
+++ b/frontend/src/app/(app)/(auth)/login/page.tsx
@@ -1,11 +1,26 @@
+'use client';
+
 import PageHeader from '@/shared/ui/header/PageHeader';
 import { Login } from '@/features/auth';
+import dynamic from 'next/dynamic';
+import PublicGuard from '@/features/auth/lib/PublicGuard';
+
+const PublicGuardClient = dynamic(() => Promise.resolve(PublicGuard), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[60vh] items-center justify-center">
+      <div className="animate-pulse rounded-xl bg-gray-100 px-6 py-4 text-gray-600">
+        로그인 여부 확인 중…
+      </div>
+    </div>
+  ),
+});
 
 export default function LoginPage() {
   return (
-    <div>
+    <PublicGuardClient>
       <PageHeader title={'로그인'} />
       <Login />
-    </div>
+    </PublicGuardClient>
   );
 }

--- a/frontend/src/app/(app)/(protected)/layout.tsx
+++ b/frontend/src/app/(app)/(protected)/layout.tsx
@@ -3,7 +3,7 @@
 import { useUserHydrated } from '@/entities/user/lib/useUserStore';
 import dynamic from 'next/dynamic';
 
-const AuthGuard = dynamic(() => import('@/features/auth/lib/AuthGuard'), {
+const AuthGuardClient = dynamic(() => import('@/features/auth/lib/AuthGuard'), {
   ssr: false,
   loading: () => (
     <div className="flex h-[60vh] items-center justify-center">
@@ -22,5 +22,5 @@ export default function AuthRequiredLayout({
   const hasHydrated = useUserHydrated();
 
   if (!hasHydrated) return null;
-  return <AuthGuard>{children}</AuthGuard>;
+  return <AuthGuardClient>{children}</AuthGuardClient>;
 }

--- a/frontend/src/features/auth/lib/PublicGuard.tsx
+++ b/frontend/src/features/auth/lib/PublicGuard.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {
+  useUserHydrated,
+  useUserStore,
+} from '@/entities/user/lib/useUserStore';
+import { useRouter } from 'next/navigation';
+import React, { useEffect } from 'react';
+
+export default function PublicGuard({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const hasHydrated = useUserHydrated();
+  const isLoggedIn = useUserStore(s => s.userState.isLoggedIn);
+
+  useEffect(() => {
+    if (!hasHydrated) return;
+    if (isLoggedIn) {
+      if (window.history.length > 1) {
+        // 이전 히스토리가 있으면 뒤로가기
+        router.back();
+      } else {
+        // 없으면 fallback
+        router.replace('/');
+      }
+    }
+  }, [hasHydrated, isLoggedIn]);
+
+  if (!hasHydrated) return null;
+  if (isLoggedIn) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/features/reservation/hook/usePostReservation.ts
+++ b/frontend/src/features/reservation/hook/usePostReservation.ts
@@ -18,7 +18,7 @@ export default function usePostReservation() {
     },
     onSuccess: data => {
       toast.success('대기 예약 완료!');
-      router.push(`/reservation/complete/${data.waitingId}`);
+      router.replace(`/reservation/complete/${data.waitingId}`);
     },
   });
 }


### PR DESCRIPTION
## 관련 이슈
close #297 

## 변경사항 설명
- 뒤로가기 버튼으로 재진입하면 안 되는 페이지로의 이동을 방지했습니다.
  - 예약 폼 제출 후 뒤로가기를 눌러도 폼 화면이 다시 노출되지 않도록 수정했습니다.
  - 카카오 로그인 완료 후, 뒤로가기를 눌렀을 때 로그인 페이지가 다시 표시되지 않도록 변경했습니다.
- 로그인한 사용자가 보면 안돼는 페이지의 진입을 막는 PublicGuard를 추가하였습니다.

## 일정
- 리뷰 요청 기한: 2025-09-16
- 머지 예정일: 2025-09-16


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: 

## 테스트 방법
- 예약 폼 제출 완료 후 뒤로가기시 폼이 보여지지 않는지 확인
- 로그인 완료후 뒤로가기시 카카오 로그인하기 페이지가 다시 보여지지 않는지 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?


## 추가 정보
- accounts.kakao.com 같은 외부 도메인 히스토리는 삭제가 불가합니다.