### PR TITLE
Feat/#312  팝업 목록 api 응답에 예약 수 추가

### DIFF
--- a/backend/src/main/java/com/example/demo/application/dto/popup/PopupCursorResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/popup/PopupCursorResponse.java
@@ -3,7 +3,19 @@ package com.example.demo.application.dto.popup;
 import java.util.List;
 
 public record PopupCursorResponse(
-    List<PopupSummaryResponse> content,
-    Long lastPopupId,
-    Boolean hasNext
-) {} 
+        List<PopupListElementResponse> content,
+        Long lastPopupId,
+        Boolean hasNext
+) {
+    public record PopupListElementResponse(
+            Long popupId,
+            String popupName,
+            String popupImageUrl,
+            LocationResponse location,
+            long dDay,
+            String period,
+            SearchTagsResponse searchTags,
+            int waitingCount
+    ) {
+    }
+}

--- a/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
+++ b/backend/src/main/java/com/example/demo/application/mapper/PopupDtoMapper.java
@@ -1,6 +1,7 @@
 package com.example.demo.application.mapper;
 
 import com.example.demo.application.dto.popup.*;
+import com.example.demo.application.dto.popup.PopupCursorResponse.PopupListElementResponse;
 import com.example.demo.domain.model.BrandStory;
 import com.example.demo.domain.model.DateRange;
 import com.example.demo.domain.model.Location;
@@ -221,6 +222,21 @@ public class PopupDtoMapper {
                 (request.region1DepthName() == null || "전국".equals(request.region1DepthName())) ? null : request.region1DepthName(),
                 request.lastPopupId(),
                 null
+        );
+    }
+
+    public PopupListElementResponse toPopupListElementResponse(Popup popup, int waitingCount) {
+        if (popup == null) return null;
+
+        return new PopupListElementResponse(
+                popup.getId(),
+                popup.getName(),
+                popup.getDisplay().mainImageUrls().getFirst(),
+                toLocationResponse(popup.getLocation()),
+                calculateDDay(popup.getSchedule().dateRange().endDate()),
+                formatPeriod(popup.getSchedule().dateRange()),
+                toSearchTagsResponse(popup),
+                waitingCount
         );
     }
 

--- a/backend/src/main/java/com/example/demo/application/service/PopupService.java
+++ b/backend/src/main/java/com/example/demo/application/service/PopupService.java
@@ -1,36 +1,30 @@
 package com.example.demo.application.service;
 
 import com.example.demo.application.dto.PopupDetailResponse;
-import com.example.demo.application.dto.popup.PopupMapRequest;
-import com.example.demo.application.dto.popup.PopupMapResponse;
-import com.example.demo.application.dto.popup.PopupFilterRequest;
-import com.example.demo.application.dto.popup.PopupSummaryResponse;
-import com.example.demo.application.dto.popup.PopupCursorResponse;
-import com.example.demo.application.dto.popup.PopupCreateRequest;
-import com.example.demo.application.dto.popup.PopupCreateResponse;
+import com.example.demo.application.dto.popup.*;
+import com.example.demo.application.dto.popup.PopupCursorResponse.PopupListElementResponse;
 import com.example.demo.application.mapper.PopupDtoMapper;
 import com.example.demo.common.exception.BusinessException;
 import com.example.demo.common.exception.ErrorType;
-
 import com.example.demo.domain.model.BrandStory;
 import com.example.demo.domain.model.popup.Popup;
 import com.example.demo.domain.model.popup.PopupMapQuery;
 import com.example.demo.domain.model.popup.PopupQuery;
 import com.example.demo.domain.model.waiting.Waiting;
+import com.example.demo.domain.model.waiting.WaitingQuery;
 import com.example.demo.domain.model.waiting.WaitingStatus;
-
 import com.example.demo.domain.port.BrandStoryPort;
 import com.example.demo.domain.port.PopupPort;
 import com.example.demo.domain.port.WaitingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -48,7 +42,7 @@ public class PopupService {
         List<Popup> popups = popupPort.findByMapQuery(query);
         return popupDtoMapper.toPopupMapResponses(popups);
     }
-  
+
     @Transactional(readOnly = true)
     public PopupCursorResponse getFilteredPopups(PopupFilterRequest request) {
         // TODO: https://github.com/JECT-Study/JECT-3th-6team/pull/92#discussion_r2210591165
@@ -56,10 +50,13 @@ public class PopupService {
         int size = Optional.ofNullable(request.size()).orElse(10);
         List<Popup> popups = popupPort.findByQuery(query);
         boolean hasNext = popups.size() > size;
-        List<PopupSummaryResponse> content = popups.stream()
-            .limit(size)
-            .map(popupDtoMapper::toPopupSummaryResponse)
-            .toList();
+        List<PopupListElementResponse> content = popups.stream()
+                .limit(size)
+                .map(popup -> {
+                    int waitingCount = waitingPort.findByQuery(WaitingQuery.forPopup(popup.getId(), WaitingStatus.WAITING)).size();
+                    return popupDtoMapper.toPopupListElementResponse(popup, waitingCount);
+                })
+                .toList();
         Long lastPopupId = content.isEmpty() ? null : content.getLast().popupId();
         return new PopupCursorResponse(content, lastPopupId, hasNext);
     }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -23,6 +23,9 @@ spring:
       hibernate:
         format_sql: false
         default_batch_fetch_size: 1000
+  h2:
+    console:
+      enabled: true
 
 logging:
   level:


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #312

## 변경사항 설명
- 팝업 목록 api 응답에 예약 수 추가
  - 기존에 예약 응답에서 같이 쓰는 dto 를 수정하기 곤란하므로 별도 dto를 사용하도록 분리
  - 새로 생성한 dto 는 응집도를 높이기 위해 `PopupCursorResponse` 의 내부 레코드로 선언

## 일정
- 리뷰 요청 기한: 2025-10-01
- 머지 예정일: 2025-10-01


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: 

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. '...' 페이지로 이동
2. '....' 버튼 클릭
3. '....' 결과 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [x] 문서를 업데이트했나요?
- [x] 코드 리뷰어를 지정했나요?
- [x] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.

## 추가 정보
추가적인 정보나 컨텍스트가 있다면 여기에 작성해주세요. 