### PR TITLE
fix: 팝업 디테일 조회시 예약 상태 표현에 밴 상태 추가 및 예약중 판단 기준 변경

### DIFF
--- a/backend/src/main/java/com/example/demo/application/dto/PopupDetailResponse.java
+++ b/backend/src/main/java/com/example/demo/application/dto/PopupDetailResponse.java
@@ -1,22 +1,28 @@
 package com.example.demo.application.dto;
 
-import com.example.demo.application.dto.popup.BrandStoryResponse;
-import com.example.demo.application.dto.popup.LocationResponse;
-import com.example.demo.application.dto.popup.PeriodResponse;
-import com.example.demo.application.dto.popup.PopupDetailInfoResponse;
-import com.example.demo.application.dto.popup.SearchTagsResponse;
-import com.example.demo.domain.model.waiting.WaitingStatus;
+import com.example.demo.application.dto.popup.*;
+
 import java.util.List;
 
 public record PopupDetailResponse(
-    Long id,
-    List<String> thumbnails,
-    int dDay,
-    String title,
-    SearchTagsResponse searchTags,
-    LocationResponse location,
-    PeriodResponse period,
-    BrandStoryResponse brandStory,
-    PopupDetailInfoResponse popupDetail,
-    WaitingStatus status
-) {}
+        Long id,
+        List<String> thumbnails,
+        int dDay,
+        String title,
+        SearchTagsResponse searchTags,
+        LocationResponse location,
+        PeriodResponse period,
+        BrandStoryResponse brandStory,
+        PopupDetailInfoResponse popupDetail,
+        WaitingStatusForPopupDetailResponse status
+) {
+
+    public enum WaitingStatusForPopupDetailResponse {
+        WAITING,    // 예약/대기중
+        VISITED,   // 방문완료
+        NONE,      // 사용 안함
+        NO_SHOW,   // 노쇼
+        STORE_BAN,
+        GLOBAL_BAN;
+    }
+}

--- a/backend/src/main/java/com/example/demo/application/service/PopupService.java
+++ b/backend/src/main/java/com/example/demo/application/service/PopupService.java
@@ -1,18 +1,22 @@
 package com.example.demo.application.service;
 
 import com.example.demo.application.dto.PopupDetailResponse;
+import com.example.demo.application.dto.PopupDetailResponse.WaitingStatusForPopupDetailResponse;
 import com.example.demo.application.dto.popup.*;
 import com.example.demo.application.dto.popup.PopupCursorResponse.PopupListElementResponse;
 import com.example.demo.application.mapper.PopupDtoMapper;
 import com.example.demo.common.exception.BusinessException;
 import com.example.demo.common.exception.ErrorType;
 import com.example.demo.domain.model.BrandStory;
+import com.example.demo.domain.model.ban.BanQuery;
+import com.example.demo.domain.model.ban.BanType;
 import com.example.demo.domain.model.popup.Popup;
 import com.example.demo.domain.model.popup.PopupMapQuery;
 import com.example.demo.domain.model.popup.PopupQuery;
 import com.example.demo.domain.model.waiting.Waiting;
 import com.example.demo.domain.model.waiting.WaitingQuery;
 import com.example.demo.domain.model.waiting.WaitingStatus;
+import com.example.demo.domain.port.BanPort;
 import com.example.demo.domain.port.BrandStoryPort;
 import com.example.demo.domain.port.PopupPort;
 import com.example.demo.domain.port.WaitingPort;
@@ -35,6 +39,7 @@ public class PopupService {
     private final BrandStoryPort brandStoryPort;
     private final PopupDtoMapper popupDtoMapper;
     private final WaitingPort waitingPort;
+    private final BanPort banPort;
 
     @Transactional(readOnly = true)
     public List<PopupMapResponse> getPopupsOnMap(PopupMapRequest request) {
@@ -69,7 +74,7 @@ public class PopupService {
         var brandStory = brandStoryPort.findByPopupId(popupId)
                 .orElse(new BrandStory(Collections.emptyList(), Collections.emptyList()));
         long dDay = ChronoUnit.DAYS.between(LocalDate.now(), popup.getSchedule().dateRange().endDate());
-        WaitingStatus status = calculateReservationStatus(popupId, memberId);
+        WaitingStatusForPopupDetailResponse status = calculateReservationStatus(popupId, memberId);
 
         return new PopupDetailResponse(
                 popup.getId(),
@@ -85,12 +90,25 @@ public class PopupService {
         );
     }
 
-    private WaitingStatus calculateReservationStatus(Long popupId, Long memberId) {
-        if (memberId == null) return WaitingStatus.NONE;
+    private WaitingStatusForPopupDetailResponse calculateReservationStatus(Long popupId, Long memberId) {
+        if (memberId == null) return WaitingStatusForPopupDetailResponse.NONE;
 
-        return waitingPort.findByMemberIdAndPopupId(memberId, popupId)
-                .map(Waiting::status)
-                .orElse(WaitingStatus.NONE);
+        boolean isStoreBan = !banPort.findByQuery(BanQuery.byMemberAndPopup(memberId, popupId)).isEmpty();
+        boolean isGlobalBan = !banPort.findByQuery(BanQuery.byBanType(BanType.GLOBAL)).isEmpty();
+
+        if (isStoreBan) return WaitingStatusForPopupDetailResponse.STORE_BAN;
+        if (isGlobalBan) return WaitingStatusForPopupDetailResponse.GLOBAL_BAN;
+
+        List<Waiting> waitings = waitingPort.findByQuery(WaitingQuery.forMemberAndPopupOnDate(memberId, popupId, LocalDate.now()));
+        if (waitings.isEmpty()) return WaitingStatusForPopupDetailResponse.NONE;
+
+        boolean isWaiting = waitings.stream().anyMatch(it -> it.status() == WaitingStatus.WAITING);
+        boolean isVisited = waitings.stream().anyMatch(it -> it.status() == WaitingStatus.VISITED);
+        boolean isNoShow = waitings.stream().anyMatch(it -> it.status() == WaitingStatus.NO_SHOW);
+        if (isWaiting) return WaitingStatusForPopupDetailResponse.WAITING;
+        if (isVisited) return WaitingStatusForPopupDetailResponse.VISITED;
+        if (isNoShow) return WaitingStatusForPopupDetailResponse.NO_SHOW;
+        return WaitingStatusForPopupDetailResponse.NONE;
     }
 
     @Transactional

--- a/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/BanPortAdaptor.java
+++ b/backend/src/main/java/com/example/demo/infrastructure/persistence/adapter/BanPortAdaptor.java
@@ -18,6 +18,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -59,6 +60,11 @@ public class BanPortAdaptor implements BanPort {
             }
             case null, default -> throw new BusinessException(ErrorType.FEATURE_NOT_IMPLEMENTED);
         }
+
+        if (query.isActiveOnly()) {
+            builder.and(banEntity.endAt.goe(LocalDateTime.now()));
+        }
+
         List<BanEntity> banEntities = jpaQueryFactory.selectFrom(banEntity)
                 .where(builder)
                 .fetch();


### PR DESCRIPTION
## 관련 이슈
이 PR이 해결하는 이슈 번호를 작성해주세요.
close #324 

## 변경사항 설명

- 팝업 디테일 조회시 예약 상태 표현에 밴 상태 추가 및 예약중 판단 기준 변경
  - 별도 클래스 사용, 당일 예약만 포함하도록 수정 

## 일정
- 리뷰 요청 기한: 2025-10-09
- 머지 예정일: 2025-10-09


## 리뷰 포인트
코드 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요.
- 아키텍처 관련: 
- 성능 관련: 
- 보안 관련: 
- 기타: 

## 테스트 방법
변경사항을 테스트하는 방법을 설명해주세요:
1. '...' 페이지로 이동
2. '....' 버튼 클릭
3. '....' 결과 확인

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [ ] 코드 리뷰어를 지정했나요?
- [ ] 관련 이슈를 연결했나요?

## 스크린샷
가능한 경우, 변경사항을 보여주는 스크린샷을 추가해주세요.

## 추가 정보
추가적인 정보나 컨텍스트가 있다면 여기에 작성해주세요. 